### PR TITLE
Fixing CI to use branch caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@
 name: build
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master , develop ]
+  pull_request:
+   
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # CI workflow summary:
 # - build
-#   1. Caching
+#   1. Branch caching
 #   2. Setup Haskell
 #   3. Add .cabal/bin into PATH
 #   4. Checkout Agda repository
@@ -41,11 +41,11 @@ jobs:
             dist-newstyle
             agda
             main/_build
-          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**') }}
+          key: ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}-
-            ${{ runner.os }}-build-${{ matrix.agda }}-
-            ${{ runner.os }}-
+            ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-
+            ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-
+            ${{ runner.os }}-build-${{ github.ref }}-
 
       - uses: haskell/actions/setup@v1
         name: Setup Haskell

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ on:
   push:
     branches: [ master , develop ]
   pull_request:
+    branches:
+      - master
    
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,14 @@
 # CI workflow summary:
-# - build
+# - build: install haskell and agda, and make them available for other jobs
 #   0. Cancel Previous Runs
 #   1. Branch caching
 #   2. Setup Haskell
 #   3. Add .cabal/bin into PATH
 #   4. Checkout Agda repository
 #   5. Install Agda
+# - check: i) use the cache to get haskell and agda. 
+#          ii) see if there some cache for typechecking `main/_build` in the branch build.
+#          iii) if so, it tries to check the agda files.
 #   6. Checkout the main repository
 #   7. Verify the whole formalisation
 # - html
@@ -32,7 +35,6 @@ jobs:
         os: [ macOS-latest , ubuntu-latest ]
         agda: ["v2.6.2"]
         ghc: ["8.10.7"]
-
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -40,21 +42,18 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/cache@v2
         name: Caching
-        id: cache
+        id: cache-build
         env:
-          cache-name: cache-env
+          cache-name: cache-haskell-agda
         with:
           path: |
             ~/.cabal
             dist-newstyle
             agda
-            main/_build
-          key: ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**') }}
+          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-
-            ${{ runner.os }}-build-${{ github.ref }}-${{ matrix.agda }}-
-            ${{ runner.os }}-build-${{ github.ref }}-
-
+            ${{ runner.os }}-build-${{ matrix.agda }}-
+            ${{ runner.os }}-build-
       - uses: haskell/actions/setup@v1
         name: Setup Haskell
         with:
@@ -67,19 +66,52 @@ jobs:
 
       - uses: actions/checkout@v2
         name: Checkout Agda repository
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-build.outputs.cache-hit != 'true'
         with:
           repository: agda/agda
           path: agda
           ref: ${{ matrix.agda }}
 
       - name: Install Agda
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
           cd agda
           touch doc/user-manual.pdf
           cabal install --overwrite-policy=always --ghc-options='-O2 +RTS -M6G -RTS' -foptimise-heavily
         shell: bash
+
+  check:
+    needs: build
+    runs-on: ${{ matrix.os }}
+     strategy:
+      matrix:
+        agda: ["v2.6.2"]
+        ghc: ["8.10.7"]  
+    steps:
+      - uses: actions/cache@v2 
+        id: cache-build
+        with:
+          path: |
+            ~/.cabal
+            dist-newstyle
+            agda
+          key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}
+      - name: Add .cabal/bin into PATH
+        run:
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - uses: actions/cache@v2
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        env:
+          cache-name: cache-agda-formalisation
+        with:
+          path: main/_build
+          key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**') }}
+          restore-keys: |
+            ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-
+            ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-
+            ${{ runner.os }}-check-${{ github.ref }}-       
 
       - name: Checkout the main repository
         uses: actions/checkout@v2
@@ -87,7 +119,7 @@ jobs:
           path: main
 
       - name: Verify the whole formalisation
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-build.outputs.cache-hit != 'true'
         id: typecheck
         run: |
           cd main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@
 #   10. Generate HTML
 #   11. Deploy HTML to github pages
 
-name: build
+name: CI
 on:
   push:
     branches: [ master , develop ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         ghc: ["8.10.7"]
 
     steps:
-      - name: Cancel Previous Runs
+      - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches: [ master , develop ]
   pull_request:
+    types: [opened]
     branches:
       - master
    

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
   check:
     needs: build
     runs-on: ${{ matrix.os }}
-     strategy:
+    strategy:
       matrix:
         agda: ["v2.6.2"]
         ghc: ["8.10.7"]  
@@ -126,7 +126,7 @@ jobs:
           make check
 
   website:
-    needs: build
+    needs: check
     runs-on: macOS-latest
     if:  ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     strategy:
@@ -140,12 +140,16 @@ jobs:
             ~/.cabal
             dist-newstyle
             agda
-            main/_build
           key: ${{ runner.os }}-build-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**')}}
       - name: Add .cabal/bin into PATH
         run:
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         shell: bash
+      - uses: actions/cache@v2 
+        with:
+          path: main/_build
+          key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**')}}
+
       - name: Checkout the main repository
         uses: actions/checkout@v2
         with:
@@ -160,7 +164,6 @@ jobs:
       - run: echo "# Test" | pandoc -t html
 
       - name: Generate HTML
-        if: steps.typecheck.outputs.cache-hit != 'true' 
         id: html
         run: |
           cd main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
 
       - uses: actions/cache@v2
-        if: steps.cache-build.outputs.cache-hit != 'true'
+        if: steps.cache-agda-formalisation.outputs.cache-hit != 'true'
         env:
           cache-name: cache-agda-formalisation
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,8 +85,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ macOS-latest , ubuntu-latest ]
         agda: ["v2.6.2"]
-        ghc: ["8.10.7"]  
+        ghc: ["8.10.7"]
     steps:
       - uses: actions/cache@v2 
         id: cache-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,10 @@ jobs:
         run:
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         shell: bash
-
+      - name: Checkout the main repository
+        uses: actions/checkout@v2
+        with:
+          path: main
       - uses: actions/cache@v2
         if: steps.cache-agda-formalisation.outputs.cache-hit != 'true'
         env:
@@ -113,14 +116,8 @@ jobs:
             ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-
             ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-
             ${{ runner.os }}-check-${{ github.ref }}-       
-
-      - name: Checkout the main repository
-        uses: actions/checkout@v2
-        with:
-          path: main
-
       - name: Verify the whole formalisation
-        if: steps.cache-build.outputs.cache-hit != 'true'
+        if: steps.cache-agda-formalisation.cache-hit != 'true'
         id: typecheck
         run: |
           cd main
@@ -135,6 +132,10 @@ jobs:
         agda: ["v2.6.2"]
         ghc: ["8.10.7"]  
     steps:
+      - name: Checkout the main repository
+        uses: actions/checkout@v2
+        with:
+          path: main
       - uses: actions/cache@v2 
         with:
           path: |
@@ -150,12 +151,6 @@ jobs:
         with:
           path: main/_build
           key: ${{ runner.os }}-check-${{ github.ref }}-${{ matrix.agda }}-${{ matrix.ghc }}-${{ hashFiles('main/src/**')}}
-
-      - name: Checkout the main repository
-        uses: actions/checkout@v2
-        with:
-          path: main
-
       - name: Setup Graphviz to generate the Agda dependency graph
         uses: ts-graphviz/setup-graphviz@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 # CI workflow summary:
 # - build
+#   0. Cancel Previous Runs
 #   1. Branch caching
 #   2. Setup Haskell
 #   3. Add .cabal/bin into PATH
@@ -30,6 +31,10 @@ jobs:
         ghc: ["8.10.7"]
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/cache@v2
         name: Caching
         id: cache

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 
 checkOpts :=--without-K --exact-split
 everythingOpts :=$(checkOpts) --allow-unsolved-metas
-agdaVerbose?=0
-# export agdaVerbose=20 if you want to see all
+agdaVerbose?=1
+# use "$ export agdaVerbose=20" if you want to see all
+AGDA_FILES := $(wildcard ./src/**/*.lagda.md)
+bar := $(foreach f,$(AGDA_FILES),$(shell wc -l $(f))"\n")
 
 htmlOpts=--html --html-highlight=code --html-dir=docs --css=docs/Agda.css
 AGDA ?=agda -v$(agdaVerbose)
@@ -11,10 +13,15 @@ TIME ?=time
 .PHONY : agdaFiles
 agdaFiles : 
 	@rm -rf $@
-	@rm -rf src/everything.lagda.md ;\
-	find src -type f \( -name "*.agda" -o -name "*.lagda"  -o -name  "*.lagda.md" \) > $@; \
-	sort -o $@ $@; \
-	wc -l $@
+	@rm -rf src/everything.lagda.md
+	@find src -type f \( -name "*.agda" -o -name "*.lagda"  -o -name  "*.lagda.md" \) > $@
+	@sort -o $@ $@
+	@wc -l $@
+	@echo "$(shell (find src -name '*.lagda.md' -print0 | xargs -0 cat ) | wc -l) LOC"
+
+
+# for p in $(shell cat $@); do echo $(shell wc -l $p); done
+
 
 .PHONY : src/everything.lagda.md
 src/everything.lagda.md : agdaFiles

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Agda formalisation of the Symmetry book [![build](https://github.com/UniMath/SymmetryBookFormalization/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/UniMath/SymmetryBookFormalization/actions/workflows/ci.yaml)
+# Agda formalisation of the Symmetry Book [[![type checking](https://github.com/UniMath/SymmetryBookFormalization/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/UniMath/SymmetryBookFormalization/actions/workflows/ci.yaml))
 
-This repository is for a formalisation project in Agda of the symmetry book.
+This repository is for a formalisation project in Agda of the Symmetry Book.
 
 ## Members of the formalisation project 
+
 Elisabeth Bonnevier, Pierre Cagne, Jonathan Prieto-Cubides, Egbert Rijke.
 
 ## Structure of the library
 
 The Agda source of the library can be found in the folder `src`. This folder contains several subfolders:
-1. The `foundations` folder contains a general development of the univalent foundations for mathematics. The material in this folder exceeds the material in Chapter 2 of the symmetry book. The files of this library originate from the formalisation of the [Introduction to Homotopy Type Theory](https://github.com/HoTT-Intro/Agda) book by Egbert Rijke.
+1. The `foundations` folder contains a general development of the univalent foundations for mathematics. The material in this folder exceeds the material in Chapter 2 of the Symmetry Book. The files of this library originate from the formalisation of the [Introduction to Homotopy Type Theory](https://github.com/HoTT-Intro/Agda) book by Egbert Rijke.
 2. The `categories` folder contains some category theory.
 3. The `the-circle` folder contains the material for Chapter 3.
 4. The `groups` folder contains the material for Chapter 4.
@@ -21,23 +22,27 @@ The library is built in Agda 2.6.2. It can be compiled by running `make check` f
 ## Conventions
 
 ### Names in the library
+
 The naming convention in this library is such that the name of a construction closely matches the type of the construction. For example, the proof that the successor function on the integers is an equivalence has type `is-equiv succ-ℤ`. The name of the proof that the successor function on the integers is an equivalence is therefore `is-equiv-succ-ℤ`. Notice that most names are fully lowercase, and words are separated by hyphens. 
 
 Names may also refer to types of the hypotheses used in the construction. Since the first objective of a name is to describe the type of the constructed term, the description of the hypotheses comes after the description of the conclusion in a name. For example, the term `is-equiv-is-contr-map` is a function of type `is-contr-map f → is-equiv f`, where `f` is a function already assumed. This convention has the advantage that if we have `H : is-contr-map f`, then the term `is-equiv-is-contr-map H` contains the description `is-contr-map` closest to the variable `H` of which it is a description.
 
 1. The library uses Lisp style parentheses, and indent arguments of functions if they are on their own line.
-2. Names are lowercase, with words split by hyphens
+2. Names are lowercase, with words split by hyphens.
 3. Names describe the object that is constructed first. For some theorems, the later part of a name contains descriptions of the hypotheses. 
 4. The symbol for path concatenation is obtained by typing `\.`
 
 ### Characterizing identity types
+
 Identity types are characterized using `fundamental-theorem-id`, which can be found in `foundations.11-fundamental-theorem`. This theorem uses an implicit family `B` over a type `a`. The user must provide four arguments:
+
 1. The base element `a:A`.
 2. An element of type `B a`.
 3. A proof that `Σ A B` is contractible.
-4. A family of maps (x : A) → Id a x → B x.
+4. A family of maps `(x : A) → Id a x → B x`.
 
 The characterization of an identity type therefore revolves around the proof of contractibility of a total space. In order to give proofs of contractibility efficiently, the following theorems are often used:
+
 1. `is-contr-equiv` and `is-contr-equiv'`. These are used to show that the asserted type is equivalent to a contractible type and therefore contractible. The `'` just switches the direction of the equivalence, so that it doesn't have to be manually inverted.
 2. The structure identity principle `is-contr-total-Eq-structure`.
 3. The substructure identity principle `is-contr-total-Eq-substructure`.

--- a/src/subgroups.lagda.md
+++ b/src/subgroups.lagda.md
@@ -7,5 +7,5 @@ title: Formalisation of the Symmetry Book
 
 module subgroups where
 
-open import subgroups.abstrZZZZZact-subgroups publicasdf
+open import subgroups.abstract-subgroups publicasdf
 ```

--- a/src/subgroups.lagda.md
+++ b/src/subgroups.lagda.md
@@ -7,5 +7,5 @@ title: Formalisation of the Symmetry Book
 
 module subgroups where
 
-open import subgroups.abstrZZZZZact-subgroups public
+open import subgroups.abstrZZZZZact-subgroups publicasdf
 ```

--- a/src/subgroups.lagda.md
+++ b/src/subgroups.lagda.md
@@ -7,5 +7,5 @@ title: Formalisation of the Symmetry Book
 
 module subgroups where
 
-open import subgroups.abstract-subgroups public
+open import subgroups.abstrZZZZZact-subgroups public
 ```

--- a/src/subgroups.lagda.md
+++ b/src/subgroups.lagda.md
@@ -7,5 +7,5 @@ title: Formalisation of the Symmetry Book
 
 module subgroups where
 
-open import subgroups.abstract-subgroups publicasdf
+open import subgroups.abstract-subgroups public
 ```


### PR DESCRIPTION
This PR will solve some issues related to our previous workflow. We have divided our build into three main steps, build executables, type check and website.  We will efficiently cache the executables for type checking the Agda files. The Agda cache will only store files from the same branch. Lastly, we will automatically cancel any previous run pushed in the same branch. I believe this should be enough to get CI working correctly for a while. :)

 CI workflow summary:

 - **Build**: install Haskell and Agda, and make them available for other jobs/builds.
   1. Cancel Previous Runs
   1. Branch caching
   2. Setup Haskell
   3. Add .cabal/bin into PATH
   4. Checkout Agda repository
   5. Install Agda
   
 - **Check**: depends on Build and the branch.
   1. Use cache to get an Agda executable.
   6. Checkout the main repository
   7. Verify the whole formalisation

 - **HTML**: only depends on Check.
   1. Setup Graphviz to generate the Agda dependency graph
   9. Setup Pandoc using setup-pandoc 
   10. Generate HTML
   11. Deploy HTML to Github pages
