### PR TITLE
VSCode Literate Agda Markdown file association

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,8 +31,6 @@
   "[agda]": {
     "editor.tabSize": 2,
     "editor.rulers": [80],
-    "editor.formatOnType": true,
-    "editor.formatOnSave": true,
     "editor.quickSuggestions": {
       "other": "inline"
     },
@@ -57,7 +55,7 @@
     "editor.suggest.insertMode": "replace",
     "gitlens.codeLens.scopes": ["document"]
   },
-  "[markdown]": {
+  "[markdown][literate agda markdown]": {
     "editor.tabSize": 2,
     "editor.rulers": [80],
     "editor.quickSuggestions": {


### PR DESCRIPTION
Sets up file association with literate agda markdown files, to accommodate the newest `agda-syntax` version which defines this file format.