### PR TITLE
Prototype: shorthand for algebraic structures

### DIFF
--- a/src/group-theory/commutative-monoids.lagda.md
+++ b/src/group-theory/commutative-monoids.lagda.md
@@ -185,3 +185,56 @@ module _
   is-unit-prop-Commutative-Monoid x =
     Id-Prop (set-Commutative-Monoid M) x unit-Commutative-Monoid
 ```
+
+## Shorthand
+
+When extensively referring to a commutative monoid `M` and its properties, it
+may be easier to write `let open shorthand-Commutative-Monoid M in ...` to get
+access to a standard shorthand for `M` and its operations.
+
+```agda
+module shorthand-Commutative-Monoid {l : Level} (M : Commutative-Monoid l) where
+  type-CMon : UU l
+  type-CMon = type-Commutative-Monoid M
+
+  set-CMon : Set l
+  set-CMon = set-Commutative-Monoid M
+
+  infixl 35 _*CMon_
+
+  _*CMon_ : type-CMon → type-CMon → type-CMon
+  _*CMon_ = mul-Commutative-Monoid M
+
+  associative-*CMon :
+    (x y z : type-CMon) → (x *CMon y) *CMon z ＝ x *CMon (y *CMon z)
+  associative-*CMon = associative-mul-Commutative-Monoid M
+
+  unit-CMon : type-CMon
+  unit-CMon = unit-Commutative-Monoid M
+
+  left-unit-*-CMon : (x : type-CMon) → unit-CMon *CMon x ＝ x
+  left-unit-*-CMon = left-unit-law-mul-Commutative-Monoid M
+
+  right-unit-*-CMon : (x : type-CMon) → x *CMon unit-CMon ＝ x
+  right-unit-*-CMon = right-unit-law-mul-Commutative-Monoid M
+
+  commutative-*CMon : (x y : type-CMon) → x *CMon y ＝ y *CMon x
+  commutative-*CMon = commutative-mul-Commutative-Monoid M
+
+  left-swap-*CMon :
+    (x y z : type-CMon) → x *CMon (y *CMon z) ＝ y *CMon (x *CMon z)
+  left-swap-*CMon = left-swap-mul-Commutative-Monoid M
+
+  right-swap-*CMon :
+    (x y z : type-CMon) → (x *CMon y) *CMon z ＝ (x *CMon z) *CMon y
+  right-swap-*CMon = right-swap-mul-Commutative-Monoid M
+
+  interchange-*CMon-*CMon :
+    (x y z w : type-CMon) →
+    (x *CMon y) *CMon (z *CMon w) ＝ (x *CMon z) *CMon (y *CMon w)
+  interchange-*CMon-*CMon = interchange-mul-mul-Commutative-Monoid M
+
+  ap-*CMon :
+    {x x' y y' : type-CMon} → x ＝ x' → y ＝ y' → x *CMon y ＝ x' *CMon y'
+  ap-*CMon = ap-mul-Commutative-Monoid M
+```

--- a/src/group-theory/monoids.lagda.md
+++ b/src/group-theory/monoids.lagda.md
@@ -174,6 +174,43 @@ pr1 (pr2 (pr2 (pr2 (pr2 (wild-monoid-Monoid M))))) x y =
 pr2 (pr2 (pr2 (pr2 (pr2 (wild-monoid-Monoid M))))) = star
 ```
 
+## Shorthand
+
+When extensively referring to a monoid `M` and its properties, it may be
+easier to write `let open shorthand-Monoid M in ...` to get access to a
+standard shorthand for `M` and its operations.
+
+```agda
+module shorthand-Monoid {l : Level} (M : Monoid l) where
+  type-Mon : UU l
+  type-Mon = type-Monoid M
+
+  set-Mon : Set l
+  set-Mon = set-Monoid M
+
+  infixl 35 _*Mon_
+
+  _*Mon_ : type-Mon → type-Mon → type-Mon
+  _*Mon_ = mul-Monoid M
+
+  associative-*Mon :
+    (x y z : type-Mon) → (x *Mon y) *Mon z ＝ x *Mon (y *Mon z)
+  associative-*Mon = associative-mul-Monoid M
+
+  unit-Mon : type-Mon
+  unit-Mon = unit-Monoid M
+
+  left-unit-*-Mon : (x : type-Mon) → unit-Mon *Mon x ＝ x
+  left-unit-*-Mon = left-unit-law-mul-Monoid M
+
+  right-unit-*-Mon : (x : type-Mon) → x *Mon unit-Mon ＝ x
+  right-unit-*-Mon = right-unit-law-mul-Monoid M
+
+  ap-*Mon :
+    {x x' y y' : type-Mon} → x ＝ x' → y ＝ y' → x *Mon y ＝ x' *Mon y'
+  ap-*Mon = ap-mul-Monoid M
+```
+
 ## See also
 
 - In [one object precategories](category-theory.one-object-precategories.md), we

--- a/src/group-theory/semigroups.lagda.md
+++ b/src/group-theory/semigroups.lagda.md
@@ -114,3 +114,31 @@ semigroup-structure-semigroup :
 pr1 (semigroup-structure-semigroup X (s , g)) = X , s
 pr2 (semigroup-structure-semigroup X (s , g)) = g
 ```
+
+## Shorthand
+
+When extensively referring to a semigroup `G` and its properties, it may be
+easier to write `let open shorthand-Semigroup G in ...` to get access to a
+standard shorthand for `G` and its operations.
+
+```agda
+module shorthand-Semigroup {l : Level} (G : Semigroup l) where
+  type-Sgrp : UU l
+  type-Sgrp = type-Semigroup G
+
+  set-Sgrp : Set l
+  set-Sgrp = set-Semigroup G
+
+  infixl 35 _*Sgrp_
+
+  _*Sgrp_ : type-Sgrp → type-Sgrp → type-Sgrp
+  _*Sgrp_ = mul-Semigroup G
+
+  associative-*Sgrp :
+    (x y z : type-Sgrp) → (x *Sgrp y) *Sgrp z ＝ x *Sgrp (y *Sgrp z)
+  associative-*Sgrp = associative-mul-Semigroup G
+
+  ap-*Sgrp :
+    {x x' y y' : type-Sgrp} → x ＝ x' → y ＝ y' → x *Sgrp y ＝ x' *Sgrp y'
+  ap-*Sgrp = ap-mul-Semigroup G
+```


### PR DESCRIPTION
It has been very painful to do lots of algebra with algebraic structures due to the long function names that must be retyped (and formatted, and indented increasingly deeply) with every operation.

This is a prototype example of a possible solution that attempts to _standardize_ a shorthand.  The idea is to write something like

```
let open shorthand-Monoid Some-Monoid in
...(x *Mon y)...
```

...sticking to what seem to be the "standard" mathematical abbreviations for the category of the described algebraic type: `Grp`, `Sgrp`, `Mon`, `CMon`, and so on.  I am not currently abbreviating any of the property names like `associative`, `interchange`, or `commutative`.

The hope is that this being standardized and easy to use locally -- e.g. not reinventing which names to use every time shorthand is required -- this might be more acceptable than more extensive use of `let` local variables.

(I remain deeply convinced that one should use `let` any time an expression could be given a shorter self-explanatory name than its definition, regardless of the number of times the expression is used, and that this codebase would be more maintainable in every respect with that philosophy, but that's a separate issue.)