### PR TITLE
Disable macOS runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-13, ubuntu-latest]
+        os: [ubuntu-latest]
         agda: ['2.7.0']
     steps:
       - name: Checkout our repository


### PR DESCRIPTION
It's at times 3x slower than the Ubuntu one, and its time is billed 10x (if we were billed for CI).
Merging it will probably require fiddling with repo settings, since the macOS run is still tagged as required before merging. Though we apparently have plenty of time, since we're banned from GitHub actions for now anyway.