### PR TITLE
strictly increasing real maps on proper closed real intervals

### DIFF
--- a/src/real-numbers.lagda.md
+++ b/src/real-numbers.lagda.md
@@ -121,6 +121,7 @@ open import real-numbers.rational-approximates-of-real-numbers public
 open import real-numbers.rational-lower-dedekind-real-numbers public
 open import real-numbers.rational-real-numbers public
 open import real-numbers.rational-upper-dedekind-real-numbers public
+open import real-numbers.real-maps-proper-closed-intervals-real-numbers public
 open import real-numbers.real-numbers-from-lower-dedekind-real-numbers public
 open import real-numbers.real-numbers-from-upper-dedekind-real-numbers public
 open import real-numbers.real-sequences-approximating-zero public
@@ -140,6 +141,7 @@ open import real-numbers.strict-inequality-positive-real-numbers public
 open import real-numbers.strict-inequality-real-numbers public
 open import real-numbers.strictly-increasing-endomaps-real-numbers public
 open import real-numbers.strictly-increasing-pointwise-epsilon-delta-continuous-endomaps-real-numbers public
+open import real-numbers.strictly-increasing-real-maps-proper-closed-intervals-real-numbers public
 open import real-numbers.subsets-real-numbers public
 open import real-numbers.sums-of-finite-sequences-of-nonnegative-real-numbers public
 open import real-numbers.sums-of-finite-sequences-of-real-numbers public

--- a/src/real-numbers.lagda.md
+++ b/src/real-numbers.lagda.md
@@ -74,6 +74,7 @@ open import real-numbers.local-ring-of-real-numbers public
 open import real-numbers.located-metric-space-of-real-numbers public
 open import real-numbers.lower-dedekind-real-numbers public
 open import real-numbers.macneille-real-numbers public
+open import real-numbers.maps-between-proper-closed-intervals-real-numbers public
 open import real-numbers.maximum-finite-families-nonnegative-real-numbers public
 open import real-numbers.maximum-finite-families-real-numbers public
 open import real-numbers.maximum-inhabited-finitely-enumerable-subsets-real-numbers public

--- a/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
@@ -31,7 +31,7 @@ of [functions](foundation.function-types.md) `I → J`, i.e., the type of
 
 ## Definition
 
-### The type of real maps on a proper closed interval of real numbers
+### Maps between proper closed intervals of real numbers
 
 ```agda
 module _

--- a/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
@@ -1,0 +1,78 @@
+# Functions between proper closed intervals of real numbers
+
+```agda
+{-# OPTIONS --lossy-unification #-}
+
+module real-numbers.maps-between-proper-closed-intervals-real-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.universe-levels
+
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.proper-closed-intervals-real-numbers
+```
+
+</details>
+
+## Idea
+
+The type of
+{{#concept "maps" Disambiguation="between proper closed intervals" Agda=map-proper-closed-interval-ℝ}}
+between
+[proper closed intervals](real-numbers.proper-closed-intervals-real-numbers.md)
+of [real numbers](real-numbers.dedekind-real-numbers.md) `I` and `J` is the type
+of [functions](foundation.function-types.md) `I → J`, i.e., the type of
+[real maps](real-numbers.real-maps-proper-closed-intervals-real-numbers.md) on
+`I` with values [in](foundation.subtypes.md) `J`.
+
+## Definition
+
+### The type of real maps on a proper closed interval of real numbers
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} (l l' : Level)
+  (I : proper-closed-interval-ℝ l1 l2)
+  (J : proper-closed-interval-ℝ l3 l4)
+  where
+
+  map-proper-closed-interval-ℝ :
+    UU (lsuc l ⊔ lsuc l' ⊔ l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  map-proper-closed-interval-ℝ =
+    type-proper-closed-interval-ℝ l I → type-proper-closed-interval-ℝ l' J
+```
+
+## Properties
+
+### The identity map on a proper closed interval
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level} (l : Level)
+  (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  id-proper-closed-interval-ℝ : map-proper-closed-interval-ℝ l l I I
+  id-proper-closed-interval-ℝ = id
+```
+
+### Composition of maps between proper closed intervals
+
+```agda
+module _
+  {l1 l2 l3 l4 l5 l6 l l' l'' : Level}
+  {I : proper-closed-interval-ℝ l1 l2}
+  {J : proper-closed-interval-ℝ l3 l4}
+  {K : proper-closed-interval-ℝ l5 l6}
+  (g : map-proper-closed-interval-ℝ l' l'' J K)
+  (f : map-proper-closed-interval-ℝ l l' I J)
+  where
+
+  comp-map-proper-closed-interval-ℝ : map-proper-closed-interval-ℝ l l'' I K
+  comp-map-proper-closed-interval-ℝ = g ∘ f
+```

--- a/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/maps-between-proper-closed-intervals-real-numbers.lagda.md
@@ -9,7 +9,6 @@ module real-numbers.maps-between-proper-closed-intervals-real-numbers where
 <details><summary>Imports</summary>
 
 ```agda
-open import foundation.dependent-pair-types
 open import foundation.function-types
 open import foundation.universe-levels
 

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -102,6 +102,14 @@ upper-bound-proper-closed-interval-ℝ :
   {l1 l2 : Level} → proper-closed-interval-ℝ l1 l2 → ℝ l2
 upper-bound-proper-closed-interval-ℝ (a , b , a<b) = b
 
+abstract
+  le-bounds-proper-closed-interval-ℝ :
+    {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2) →
+    le-ℝ
+      ( lower-bound-proper-closed-interval-ℝ I)
+      ( upper-bound-proper-closed-interval-ℝ I)
+  le-bounds-proper-closed-interval-ℝ (a , b , a<b) = a<b
+
 subtype-proper-closed-interval-ℝ :
   {l1 l2 : Level} (l : Level) → proper-closed-interval-ℝ l1 l2 →
   subset-ℝ (l1 ⊔ l2 ⊔ l) l
@@ -128,6 +136,99 @@ width-proper-closed-interval-ℝ (a , b , _) = b -ℝ a
 ```
 
 ## Properties
+
+### Similarity of real numbers preserves proper closed intervals
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  is-in-proper-closed-interval-sim-ℝ :
+    {l3 l4 : Level} {x : ℝ l3} {y : ℝ l4} →
+    sim-ℝ x y →
+    is-in-proper-closed-interval-ℝ I x →
+    is-in-proper-closed-interval-ℝ I y
+  is-in-proper-closed-interval-sim-ℝ x~y (a≤x , x≤b) =
+    ( preserves-leq-right-sim-ℝ x~y a≤x ,
+      preserves-leq-left-sim-ℝ x~y x≤b)
+```
+
+### A proper closed interval contains its bounds
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  abstract
+    is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ :
+      is-in-proper-closed-interval-ℝ I (lower-bound-proper-closed-interval-ℝ I)
+    is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ =
+      ( refl-leq-ℝ (lower-bound-proper-closed-interval-ℝ I) ,
+        leq-le-ℝ (le-bounds-proper-closed-interval-ℝ I))
+
+  in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ :
+    type-proper-closed-interval-ℝ l1 I
+  in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ =
+    ( lower-bound-proper-closed-interval-ℝ I ,
+      is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ)
+
+  in-proper-closed-interval-sim-lower-bound-proper-closed-interval-ℝ :
+    {l3 : Level} (x : ℝ l3) →
+    sim-ℝ (lower-bound-proper-closed-interval-ℝ I) x →
+    type-proper-closed-interval-ℝ l3 I
+  in-proper-closed-interval-sim-lower-bound-proper-closed-interval-ℝ x a~x =
+    ( x ,
+      is-in-proper-closed-interval-sim-ℝ I
+        ( a~x)
+        ( is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ))
+
+  abstract
+    is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ :
+      is-in-proper-closed-interval-ℝ I (upper-bound-proper-closed-interval-ℝ I)
+    is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ =
+      ( leq-le-ℝ (le-bounds-proper-closed-interval-ℝ I) ,
+        refl-leq-ℝ (upper-bound-proper-closed-interval-ℝ I))
+
+  in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ :
+    type-proper-closed-interval-ℝ l2 I
+  in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ =
+    ( upper-bound-proper-closed-interval-ℝ I ,
+      is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ)
+
+  in-proper-closed-interval-sim-upper-bound-proper-closed-interval-ℝ :
+    {l3 : Level} (x : ℝ l3) →
+    sim-ℝ (upper-bound-proper-closed-interval-ℝ I) x →
+    type-proper-closed-interval-ℝ l3 I
+  in-proper-closed-interval-sim-upper-bound-proper-closed-interval-ℝ x b~x =
+    ( x ,
+      is-in-proper-closed-interval-sim-ℝ I
+        ( b~x)
+        ( is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ))
+```
+
+### The bounds of a proper closed interval bound its elements
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  leq-lower-bound-proper-closed-interval-ℝ :
+    {l3 : Level} (x : type-proper-closed-interval-ℝ l3 I) →
+    leq-ℝ
+      ( lower-bound-proper-closed-interval-ℝ I)
+      ( pr1 x)
+  leq-lower-bound-proper-closed-interval-ℝ (x , a≤x , x≤b) = a≤x
+
+  leq-upper-bound-proper-closed-interval-ℝ :
+    {l3 : Level} (x : type-proper-closed-interval-ℝ l3 I) →
+    leq-ℝ
+      ( pr1 x)
+      ( upper-bound-proper-closed-interval-ℝ I)
+  leq-upper-bound-proper-closed-interval-ℝ (x , a≤x , x≤b) = x≤b
+```
 
 ### The metric space associated with a proper closed interval
 
@@ -861,4 +962,78 @@ module _
                   ( real-ℚ⁺ ε'')
                   ( is-positive-real-ℚ⁺ ε'')))
           ( cotransitive-le-ℝ a xℝ b a<b)
+```
+
+### Raising elements of proper closed interval
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  raise-type-proper-closed-interval-ℝ :
+    {l0 : Level} (l : Level) →
+    type-proper-closed-interval-ℝ l0 I →
+    type-proper-closed-interval-ℝ (l0 ⊔ l) I
+  raise-type-proper-closed-interval-ℝ l (x , x∈I) =
+    ( raise-ℝ l x ,
+      is-in-proper-closed-interval-sim-ℝ
+        ( I)
+        ( sim-raise-ℝ l x)
+        ( x∈I))
+```
+
+### Raising the universe levels of the bounds of a proper closed interval
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  (l : Level)
+  where
+
+  raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ :
+    type-proper-closed-interval-ℝ (l ⊔ l1 ⊔ l2) I
+  raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ =
+    raise-type-proper-closed-interval-ℝ I l2
+      ( raise-type-proper-closed-interval-ℝ I l
+        ( in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ I))
+
+  sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ :
+    sim-ℝ
+      ( lower-bound-proper-closed-interval-ℝ I)
+      ( pr1
+        raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ)
+  sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ =
+    transitive-sim-ℝ
+      ( lower-bound-proper-closed-interval-ℝ I)
+      ( pr1
+        ( raise-type-proper-closed-interval-ℝ I l
+          ( in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ I)))
+      ( pr1
+        ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ))
+      ( sim-raise-ℝ l2 _)
+      ( sim-raise-ℝ l _)
+
+  raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ :
+    type-proper-closed-interval-ℝ (l ⊔ l1 ⊔ l2) I
+  raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ =
+    raise-type-proper-closed-interval-ℝ I l1
+      ( raise-type-proper-closed-interval-ℝ I l
+        ( in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ I))
+
+  sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ :
+    sim-ℝ
+      ( upper-bound-proper-closed-interval-ℝ I)
+      ( pr1
+        raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ)
+  sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ =
+    transitive-sim-ℝ
+      ( upper-bound-proper-closed-interval-ℝ I)
+      ( pr1
+        ( raise-type-proper-closed-interval-ℝ I l
+          ( in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ I)))
+      ( pr1
+        ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ))
+      ( sim-raise-ℝ l1 _)
+      ( sim-raise-ℝ l _)
 ```

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -944,7 +944,7 @@ module _
           ( cotransitive-le-ℝ a xℝ b a<b)
 ```
 
-### Raising elements of proper closed interval
+### Raising universe levels of elements of proper closed interval
 
 ```agda
 module _

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -174,16 +174,6 @@ module _
     ( lower-bound-proper-closed-interval-ℝ I ,
       is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ)
 
-  in-proper-closed-interval-sim-lower-bound-proper-closed-interval-ℝ :
-    {l3 : Level} (x : ℝ l3) →
-    sim-ℝ (lower-bound-proper-closed-interval-ℝ I) x →
-    type-proper-closed-interval-ℝ l3 I
-  in-proper-closed-interval-sim-lower-bound-proper-closed-interval-ℝ x a~x =
-    ( x ,
-      is-in-proper-closed-interval-sim-ℝ I
-        ( a~x)
-        ( is-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ))
-
   abstract
     is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ :
       is-in-proper-closed-interval-ℝ I (upper-bound-proper-closed-interval-ℝ I)
@@ -196,16 +186,6 @@ module _
   in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ =
     ( upper-bound-proper-closed-interval-ℝ I ,
       is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ)
-
-  in-proper-closed-interval-sim-upper-bound-proper-closed-interval-ℝ :
-    {l3 : Level} (x : ℝ l3) →
-    sim-ℝ (upper-bound-proper-closed-interval-ℝ I) x →
-    type-proper-closed-interval-ℝ l3 I
-  in-proper-closed-interval-sim-upper-bound-proper-closed-interval-ℝ x b~x =
-    ( x ,
-      is-in-proper-closed-interval-sim-ℝ I
-        ( b~x)
-        ( is-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ))
 ```
 
 ### The bounds of a proper closed interval bound its elements

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -137,7 +137,7 @@ width-proper-closed-interval-ℝ (a , b , _) = b -ℝ a
 
 ## Properties
 
-### Similarity of real numbers preserves proper closed intervals
+### Proper closed intervals are closed under similarity of real numbers
 
 ```agda
 module _

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -193,7 +193,7 @@ module _
 ```agda
 module _
   {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
-  where
+  where abstract
 
   leq-lower-bound-proper-closed-interval-ℝ :
     {l3 : Level} (x : type-proper-closed-interval-ℝ l3 I) →

--- a/src/real-numbers/real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -1,0 +1,67 @@
+# Real functions on proper closed intervals of real numbers
+
+```agda
+{-# OPTIONS --lossy-unification #-}
+
+module real-numbers.real-maps-proper-closed-intervals-real-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.universe-levels
+
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.proper-closed-intervals-real-numbers
+```
+
+</details>
+
+## Idea
+
+The type of
+{{#concept "real functions" Disambiguation="on a proper closed interval" Agda=real-map-proper-closed-interval-ℝ}}
+on a
+[proper closed interval](real-numbers.proper-closed-intervals-real-numbers.md)
+of [real numbers](real-numbers.dedekind-real-numbers.md) `[a, b]`, is the type
+of maps `[a, b] → ℝ`.
+
+## Definition
+
+### The type of real maps on a proper closed interval of real numbers
+
+```agda
+real-map-proper-closed-interval-ℝ :
+  (l1 l2 : Level) {l3 l4 : Level} ([a,b] : proper-closed-interval-ℝ l3 l4) →
+  UU (lsuc l1 ⊔ lsuc l2 ⊔ l3 ⊔ l4)
+real-map-proper-closed-interval-ℝ l1 l2 [a,b] =
+  type-proper-closed-interval-ℝ l1 [a,b] → ℝ l2
+```
+
+## Properties
+
+### A real endomap restricts to any proper closed interval
+
+```agda
+restrict-real-endomap-real-map-proper-closed-interval-ℝ :
+  {l1 l2 l3 l4 : Level} →
+  ([a,b] : proper-closed-interval-ℝ l3 l4) →
+  (f : ℝ l1 → ℝ l2) →
+  real-map-proper-closed-interval-ℝ l1 l2 [a,b]
+restrict-real-endomap-real-map-proper-closed-interval-ℝ I f (x , x∈I) = f x
+```
+
+### Clamping a real map on a proper closed interval
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 [a,b])
+  where
+
+  clamp-real-map-proper-closed-interval-ℝ : ℝ l1 → ℝ l2
+  clamp-real-map-proper-closed-interval-ℝ x =
+    f (clamp-proper-closed-interval-ℝ [a,b] x)
+```

--- a/src/real-numbers/strictly-increasing-endomaps-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-endomaps-real-numbers.lagda.md
@@ -100,8 +100,7 @@ module _
       leq-ℝ (f x) (f y) →
       leq-ℝ x y
     reflects-leq-is-strictly-increasing-endomap-ℝ x y fx≤fy =
-      leq-not-le-ℝ y x
-        ( λ x<y → not-le-leq-ℝ _ _ fx≤fy (H y x x<y))
+      leq-not-le-ℝ y x (not-le-leq-ℝ _ _ fx≤fy ∘ (H y x))
 ```
 
 ### Strictly increasing maps are embeddings

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -246,20 +246,20 @@ module _
       ( f x)
   is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
     x@(u , a≤u , u≤b) =
-    ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-      ( [a,b])
-      ( f)
-      ( H)
-      ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+    ( ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
         ( [a,b])
-        ( l1))
-      ( x)
-      ( preserves-leq-left-sim-ℝ
-        ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+        ( f)
+        ( H)
+        ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
           ( [a,b])
           ( l1))
-        ( a≤u)) ,
-      is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( x)
+        ( preserves-leq-left-sim-ℝ
+          ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+            ( [a,b])
+            ( l1))
+          ( a≤u))) ,
+      ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
         ( [a,b])
         ( f)
         ( H)
@@ -271,7 +271,7 @@ module _
           ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
             ( [a,b])
             ( l1))
-          ( u≤b)))
+          ( u≤b))))
 ```
 
 ```agda

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -231,47 +231,47 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
-  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 [a,b])
-  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
   where abstract
 
   is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    (x : type-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) [a,b]) →
+    (x : type-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) I) →
     is-in-proper-closed-interval-ℝ
       ( proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-        ( [a,b])
+        ( I)
         ( f)
         ( H))
       ( f x)
   is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-    x@(u , a≤u , u≤b) =
+    x@(u , lo-bound , hi-bound) =
     ( ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-        ( [a,b])
+        ( I)
         ( f)
         ( H)
         ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))
         ( x)
         ( preserves-leq-left-sim-ℝ
           ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-            ( [a,b])
+            ( I)
             ( l1))
-          ( a≤u))) ,
+          ( lo-bound))) ,
       ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-        ( [a,b])
+        ( I)
         ( f)
         ( H)
         ( x)
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))
         ( preserves-leq-right-sim-ℝ
           ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-            ( [a,b])
+            ( I)
             ( l1))
-          ( u≤b))))
+          ( hi-bound))))
 ```
 
 ```agda

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -1,0 +1,274 @@
+# Strictly increasing real functions on proper closed intervals of real numbers
+
+```agda
+{-# OPTIONS --lossy-unification #-}
+
+module real-numbers.strictly-increasing-real-maps-proper-closed-intervals-real-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.action-on-identifications-functions
+open import foundation.coproduct-types
+open import foundation.dependent-pair-types
+open import foundation.double-negation
+open import foundation.embeddings
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.injective-maps
+open import foundation.propositions
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import order-theory.order-preserving-maps-preorders
+open import order-theory.strict-order-preserving-maps
+open import order-theory.strict-subpreorders
+open import order-theory.subpreorders
+
+open import real-numbers.dedekind-real-numbers
+open import real-numbers.inequality-real-numbers
+open import real-numbers.proper-closed-intervals-real-numbers
+open import real-numbers.real-maps-proper-closed-intervals-real-numbers
+open import real-numbers.similarity-real-numbers
+open import real-numbers.strict-inequality-real-numbers
+```
+
+</details>
+
+## Idea
+
+A [real map](real-numbers.real-maps-proper-closed-intervals-real-numbers.md) `f`
+on a
+[proper closed interval](real-numbers.proper-closed-intervals-real-numbers.md)
+of [real numbers](real-numbers.dedekind-real-numbers.md) `[a, b]` is
+{{#concept "strictly increasing" Disambiguation="real map on proper closerd interval of real numbers" Agda=is-strictly-increasing-real-map-proper-closed-interval-ℝ}}
+if, for any `x , y ∈ [a, b]`, if `x < y`, then `f x < f y`.
+
+## Definitions
+
+### The property of being a strictly increasing real map on a proper closed interval
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  where
+
+  is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ :
+    real-map-proper-closed-interval-ℝ l1 l2 [a,b] →
+    Prop (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ =
+    preserves-strict-order-prop-map-Strict-Preorder
+      ( strict-preorder-Strict-Subpreorder
+        ( strict-preorder-ℝ l1)
+        ( subtype-proper-closed-interval-ℝ l1 [a,b]))
+      ( strict-preorder-ℝ l2)
+
+  is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    real-map-proper-closed-interval-ℝ l1 l2 [a,b] →
+    UU (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4)
+  is-strictly-increasing-real-map-proper-closed-interval-ℝ =
+    type-Prop ∘ is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ
+
+  is-prop-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b]) →
+    is-prop (is-strictly-increasing-real-map-proper-closed-interval-ℝ f)
+  is-prop-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
+    is-prop-type-Prop ∘
+    is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ
+```
+
+## Properties
+
+### A strictly increasing map on a proper closed interval is increasing
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
+  where abstract
+
+  is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f →
+    preserves-order-Preorder
+      ( preorder-Subpreorder
+        ( ℝ-Preorder l1)
+        ( subtype-proper-closed-interval-ℝ l1 [a,b]))
+      ( ℝ-Preorder l2)
+      ( f)
+  is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    H x@(u , _) y@(v , _) u≤v =
+    double-negation-elim-leq-ℝ
+      ( f x)
+      ( f y)
+      ( map-double-negation
+        ( rec-coproduct
+          ( λ u~v →
+            leq-eq-ℝ
+              ( ap f
+                ( eq-type-subtype
+                  ( subtype-proper-closed-interval-ℝ l1 [a,b])
+                  ( eq-sim-ℝ u~v))))
+          ( λ u<v → leq-le-ℝ (H x y u<v)))
+        ( irrefutable-sim-or-le-leq-ℝ u v u≤v))
+```
+
+### Strictly increasing maps on proper closed intervals reflect inequality
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  where abstract
+
+  reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    ( x@(u , _) y@(v , _) : type-proper-closed-interval-ℝ l1 [a,b]) →
+    leq-ℝ (f x) (f y) →
+    leq-ℝ u v
+  reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    x@(u , _) y@(v , _) K =
+    leq-not-le-ℝ v u (not-le-leq-ℝ (f x) (f y) K ∘ (H y x))
+```
+
+### Strictly increasing maps on proper closed intervals are embeddings
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  where abstract
+
+  is-injective-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    is-injective f
+  is-injective-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    {x@(u , _)} {y@(v , _)} fx=fy =
+    eq-type-subtype
+      ( subtype-proper-closed-interval-ℝ l1 [a,b])
+      ( antisymmetric-leq-ℝ u v
+        ( reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+          ( [a,b])
+          ( f)
+          ( H)
+          ( x)
+          ( y)
+          ( leq-eq-ℝ fx=fy))
+        ( reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+          ( [a,b])
+          ( f)
+          ( H)
+          ( y)
+          ( x)
+          ( leq-eq-ℝ (inv fx=fy))))
+
+  is-emb-is-strictly-increasing-real-map-proper-closed-interval-ℝ : is-emb f
+  is-emb-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
+    is-emb-is-injective
+      ( is-set-ℝ l2)
+      ( is-injective-is-strictly-increasing-real-map-proper-closed-interval-ℝ)
+```
+
+### The images of the bounds of a proper closed interval by a strictly increasing map are strictly ordered
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 [a,b])
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  where abstract
+
+  le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    le-ℝ
+      ( f
+        ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1)))
+      ( f
+        ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1)))
+  le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
+    H
+      ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+        ( [a,b])
+        ( l1))
+      ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+        ( [a,b])
+        ( l1))
+      ( preserves-le-sim-ℝ
+        ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))
+        ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))
+        ( le-bounds-proper-closed-interval-ℝ [a,b]))
+
+  proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    proper-closed-interval-ℝ l2 l2
+  proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    =
+    ( ( f
+        ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))) ,
+      ( f
+        ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))) ,
+      ( le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ))
+```
+
+### The image of a strictly increasing map on a proper closed interval is contained in the interval image of its bounds
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 [a,b])
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  where abstract
+
+  is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    (x : type-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) [a,b]) →
+    is-in-proper-closed-interval-ℝ
+      ( proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( [a,b])
+        ( f)
+        ( H))
+      ( f x)
+  is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    x@(u , a≤u , u≤b) =
+    ( is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+      ( [a,b])
+      ( f)
+      ( H)
+      ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+        ( [a,b])
+        ( l1))
+      ( x)
+      ( preserves-leq-left-sim-ℝ
+        ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))
+        ( a≤u)) ,
+      is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( [a,b])
+        ( f)
+        ( H)
+        ( x)
+        ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+          ( [a,b])
+          ( l1))
+        ( preserves-leq-right-sim-ℝ
+          ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+            ( [a,b])
+            ( l1))
+          ( u≤b)))
+```

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -28,6 +28,7 @@ open import order-theory.subpreorders
 
 open import real-numbers.dedekind-real-numbers
 open import real-numbers.inequality-real-numbers
+open import real-numbers.maps-between-proper-closed-intervals-real-numbers
 open import real-numbers.proper-closed-intervals-real-numbers
 open import real-numbers.real-maps-proper-closed-intervals-real-numbers
 open import real-numbers.similarity-real-numbers
@@ -271,4 +272,29 @@ module _
             ( [a,b])
             ( l1))
           ( u≤b)))
+```
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
+  where
+
+  map-proper-closed-interval-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    map-proper-closed-interval-ℝ _ _
+      ( I)
+      ( proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( I)
+        ( f)
+        ( H))
+  map-proper-closed-interval-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    x =
+    ( f x ,
+      is-in-proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( I)
+        ( f)
+        ( H)
+        ( x))
 ```

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -53,27 +53,27 @@ if, for any `x , y ∈ [a, b]`, if `x < y`, then `f x < f y`.
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
+  (I : proper-closed-interval-ℝ l3 l4)
   where
 
   is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ :
-    real-map-proper-closed-interval-ℝ l1 l2 [a,b] →
+    real-map-proper-closed-interval-ℝ l1 l2 I →
     Prop (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4)
   is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ =
     preserves-strict-order-prop-map-Strict-Preorder
       ( strict-preorder-Strict-Subpreorder
         ( strict-preorder-ℝ l1)
-        ( subtype-proper-closed-interval-ℝ l1 [a,b]))
+        ( subtype-proper-closed-interval-ℝ l1 I))
       ( strict-preorder-ℝ l2)
 
   is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    real-map-proper-closed-interval-ℝ l1 l2 [a,b] →
+    real-map-proper-closed-interval-ℝ l1 l2 I →
     UU (lsuc l1 ⊔ l2 ⊔ l3 ⊔ l4)
   is-strictly-increasing-real-map-proper-closed-interval-ℝ =
     type-Prop ∘ is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ
 
   is-prop-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b]) →
+    (f : real-map-proper-closed-interval-ℝ l1 l2 I) →
     is-prop (is-strictly-increasing-real-map-proper-closed-interval-ℝ f)
   is-prop-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
     is-prop-type-Prop ∘
@@ -87,16 +87,16 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
-  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 I)
   where abstract
 
   is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f →
+    is-strictly-increasing-real-map-proper-closed-interval-ℝ I f →
     preserves-order-Preorder
       ( preorder-Subpreorder
         ( ℝ-Preorder l1)
-        ( subtype-proper-closed-interval-ℝ l1 [a,b]))
+        ( subtype-proper-closed-interval-ℝ l1 I))
       ( ℝ-Preorder l2)
       ( f)
   is-increasing-is-strictly-increasing-real-map-proper-closed-interval-ℝ
@@ -110,7 +110,7 @@ module _
             leq-eq-ℝ
               ( ap f
                 ( eq-type-subtype
-                  ( subtype-proper-closed-interval-ℝ l1 [a,b])
+                  ( subtype-proper-closed-interval-ℝ l1 I)
                   ( eq-sim-ℝ u~v))))
           ( λ u<v → leq-le-ℝ (H x y u<v)))
         ( irrefutable-sim-or-le-leq-ℝ u v u≤v))
@@ -121,13 +121,13 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
-  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
-  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 I)
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
   where abstract
 
   reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    ( x@(u , _) y@(v , _) : type-proper-closed-interval-ℝ l1 [a,b]) →
+    ( x@(u , _) y@(v , _) : type-proper-closed-interval-ℝ l1 I) →
     leq-ℝ (f x) (f y) →
     leq-ℝ u v
   reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
@@ -140,9 +140,9 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
-  (f : real-map-proper-closed-interval-ℝ l1 l2 [a,b])
-  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ l1 l2 I)
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
   where abstract
 
   is-injective-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
@@ -150,17 +150,17 @@ module _
   is-injective-is-strictly-increasing-real-map-proper-closed-interval-ℝ
     {x@(u , _)} {y@(v , _)} fx=fy =
     eq-type-subtype
-      ( subtype-proper-closed-interval-ℝ l1 [a,b])
+      ( subtype-proper-closed-interval-ℝ l1 I)
       ( antisymmetric-leq-ℝ u v
         ( reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( f)
           ( H)
           ( x)
           ( y)
           ( leq-eq-ℝ fx=fy))
         ( reflects-leq-is-strictly-increasing-real-map-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( f)
           ( H)
           ( y)
@@ -179,37 +179,37 @@ module _
 ```agda
 module _
   {l1 l2 l3 l4 : Level}
-  ([a,b] : proper-closed-interval-ℝ l3 l4)
-  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 [a,b])
-  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ [a,b] f)
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
+  (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
   where abstract
 
   le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
     le-ℝ
       ( f
         ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1)))
       ( f
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1)))
   le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
     H
       ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-        ( [a,b])
+        ( I)
         ( l1))
       ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-        ( [a,b])
+        ( I)
         ( l1))
       ( preserves-le-sim-ℝ
         ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))
         ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))
-        ( le-bounds-proper-closed-interval-ℝ [a,b]))
+        ( le-bounds-proper-closed-interval-ℝ I))
 
   proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
     proper-closed-interval-ℝ l2 l2
@@ -217,11 +217,11 @@ module _
     =
     ( ( f
         ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))) ,
       ( f
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-          ( [a,b])
+          ( I)
           ( l1))) ,
       ( le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ))
 ```


### PR DESCRIPTION
This PR introduces the following concepts:

- `real-map-proper-closed-interval-ℝ I`: maps `I → ℝ` from a proper closed interval `I`;
- `map-proper-closed-interval-ℝ I J`: maps `I → J` between proper closed intervals;
- `is-strictly-increasing-prop-real-map-proper-closed-interval-ℝ I`: the property of being a strictly increasing  map `I → ℝ`.
