### PR TITLE
strictly increasing maps and interiors of proper closed intervals

### DIFF
--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -83,7 +83,9 @@ lower bound is
 [strictly less than](real-numbers.strict-inequality-real-numbers.md) the upper
 bound.
 
-## Definition
+## Definitions
+
+### The type of proper closed intervals of real numbers
 
 ```agda
 proper-closed-interval-ℝ : (l1 l2 : Level) → UU (lsuc l1 ⊔ lsuc l2)
@@ -133,6 +135,35 @@ positive-width-proper-closed-interval-ℝ (a , b , a<b) = positive-diff-le-ℝ a
 width-proper-closed-interval-ℝ :
   {l1 l2 : Level} → proper-closed-interval-ℝ l1 l2 → ℝ (l1 ⊔ l2)
 width-proper-closed-interval-ℝ (a , b , _) = b -ℝ a
+```
+
+### The interior of a proper closed interval
+
+```agda
+subtype-interior-proper-closed-interval-ℝ :
+  {l1 l2 : Level} (l : Level) (I : proper-closed-interval-ℝ l1 l2) →
+  subset-ℝ (l1 ⊔ l2 ⊔ l) l
+subtype-interior-proper-closed-interval-ℝ l I x =
+  le-prop-ℝ (lower-bound-proper-closed-interval-ℝ I) x ∧
+  le-prop-ℝ x (upper-bound-proper-closed-interval-ℝ I)
+
+is-interior-proper-closed-interval-ℝ :
+  {l1 l2 l : Level} (I : proper-closed-interval-ℝ l1 l2) →
+  ℝ l → UU (l1 ⊔ l2 ⊔ l)
+is-interior-proper-closed-interval-ℝ I x =
+  type-Prop (subtype-interior-proper-closed-interval-ℝ _ I x)
+
+is-prop-is-interior-proper-closed-interval-ℝ :
+  {l1 l2 l : Level} (I : proper-closed-interval-ℝ l1 l2) →
+  (x : ℝ l) → is-prop (is-interior-proper-closed-interval-ℝ I x)
+is-prop-is-interior-proper-closed-interval-ℝ I x =
+  is-prop-type-Prop (subtype-interior-proper-closed-interval-ℝ _ I x)
+
+type-interior-proper-closed-interval-ℝ :
+  {l1 l2 : Level} (l : Level) (I : proper-closed-interval-ℝ l1 l2) →
+  UU (lsuc l ⊔ l1 ⊔ l2 ⊔ lsuc l)
+type-interior-proper-closed-interval-ℝ l I =
+  type-subtype (subtype-interior-proper-closed-interval-ℝ l I)
 ```
 
 ## Properties
@@ -1016,4 +1047,33 @@ module _
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ))
       ( sim-raise-ℝ l1 _)
       ( sim-raise-ℝ l _)
+```
+
+### A proper closed interval contains its interior
+
+```agda
+module _
+  {l1 l2 l : Level} (I : proper-closed-interval-ℝ l1 l2)
+  where
+
+  is-in-proper-closed-interval-is-interior-proper-closed-interval-ℝ :
+    (x : ℝ l) →
+    is-interior-proper-closed-interval-ℝ I x →
+    is-in-proper-closed-interval-ℝ I x
+  is-in-proper-closed-interval-is-interior-proper-closed-interval-ℝ
+    x (lo-bound , hi-bound) =
+    ( leq-le-ℝ lo-bound , leq-le-ℝ hi-bound)
+
+  in-proper-closed-interval-is-interior-proper-closed-interval-ℝ :
+    (x : ℝ l) →
+    is-interior-proper-closed-interval-ℝ I x →
+    type-proper-closed-interval-ℝ l I
+  in-proper-closed-interval-is-interior-proper-closed-interval-ℝ x H =
+    ( x , is-in-proper-closed-interval-is-interior-proper-closed-interval-ℝ x H)
+
+  in-proper-interval-interior-proper-closed-interval-ℝ :
+    type-interior-proper-closed-interval-ℝ l I →
+    type-proper-closed-interval-ℝ l I
+  in-proper-interval-interior-proper-closed-interval-ℝ (x , H) =
+    in-proper-closed-interval-is-interior-proper-closed-interval-ℝ x H
 ```

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -298,3 +298,73 @@ module _
         ( H)
         ( x))
 ```
+
+### Strictly increasing maps on proper closed intervals maps interiors to interiors
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
+  (SI : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
+  where abstract
+
+  is-interior-map-is-interior-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    (x : ℝ (l1 ⊔ l3 ⊔ l4)) →
+    (H : is-interior-proper-closed-interval-ℝ I x) →
+    is-interior-proper-closed-interval-ℝ
+      ( proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( I)
+        ( f)
+        ( SI))
+      ( f
+        ( in-proper-closed-interval-is-interior-proper-closed-interval-ℝ I x H))
+  is-interior-map-is-interior-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    x H@(lo-bound , hi-bound) =
+    ( ( SI
+        ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+          ( I)
+          ( l1))
+        ( in-proper-closed-interval-is-interior-proper-closed-interval-ℝ I x H)
+        ( preserves-le-left-sim-ℝ _ _ _
+          ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1))
+          ( lo-bound))) ,
+      ( SI
+        ( in-proper-closed-interval-is-interior-proper-closed-interval-ℝ I x H)
+        ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+          ( I)
+          ( l1))
+        ( preserves-le-right-sim-ℝ _ _ _
+          ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1))
+          ( hi-bound))))
+```
+
+```agda
+module _
+  {l1 l2 l3 l4 : Level}
+  (I : proper-closed-interval-ℝ l3 l4)
+  (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
+  (SI : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
+  where
+
+  map-interior-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+    type-interior-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) I →
+    type-interior-proper-closed-interval-ℝ l2
+      ( proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( I)
+        ( f)
+        ( SI))
+  map-interior-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+    (x , H) =
+    ( f (in-proper-closed-interval-is-interior-proper-closed-interval-ℝ I x H) ,
+      is-interior-map-is-interior-is-strictly-increasing-real-map-proper-closed-interval-ℝ
+        ( I)
+        ( f)
+        ( SI)
+        ( x)
+        ( H))
+```


### PR DESCRIPTION
Follow up on #1952 

This PR introduces the notion of **interior** of a proper closed interval (not as a new module/concept, simply another part of the interface with proper closed intervals) and prove that a _strictly increasing_ map `f` on an interval `[a, b]` maps the interior of `[a, b]` to the interior of `[f(a), f(b)]`.