### PR TITLE
misc lemmas min/max/clamp real numbers

### DIFF
--- a/src/real-analysis/constructive-intermediate-value-theorem.lagda.md
+++ b/src/real-analysis/constructive-intermediate-value-theorem.lagda.md
@@ -439,7 +439,7 @@ module _
             ( f)
             ( seq-intermediate-value-theorem-ℝ n)
       in
-        clamp-leq-upper-bound-closed-interval-ℝ
+        sim-clamp-leq-upper-bound-closed-interval-ℝ
           ( unit-closed-interval-ℝ)
           ( one-half-ℝ +ℝ fcₙ *ℝ real-ℚ⁺ (inv-ℚ⁺ ε))
           ( chain-of-inequalities
@@ -579,7 +579,7 @@ module _
             ( f)
             ( seq-intermediate-value-theorem-ℝ n)
       in
-        clamp-leq-lower-bound-closed-interval-ℝ
+        sim-clamp-leq-lower-bound-closed-interval-ℝ
           ( unit-closed-interval-ℝ)
           ( one-half-ℝ +ℝ fcₙ *ℝ real-ℚ⁺ (inv-ℚ⁺ ε))
           ( chain-of-inequalities

--- a/src/real-numbers/binary-maximum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-maximum-real-numbers.lagda.md
@@ -436,3 +436,22 @@ abstract
             ( p<z))
         ( linear-leq-ℚ p q)
 ```
+
+### The maximum with a constant real is an increasing map
+
+```agda
+is-increasing-max-ℝ :
+  {l1 l2 l3 : Level} →
+  (x : ℝ l1) →
+  (y : ℝ l2) →
+  (z : ℝ l3) →
+  leq-ℝ y z →
+  leq-ℝ (max-ℝ x y) (max-ℝ x z)
+is-increasing-max-ℝ x y z H =
+  leq-max-leq-leq-ℝ
+    ( x)
+    ( y)
+    ( max-ℝ x z)
+    ( leq-left-max-ℝ x z)
+    ( transitive-leq-ℝ _ _ _ (leq-right-max-ℝ x z) H)
+```

--- a/src/real-numbers/binary-minimum-real-numbers.lagda.md
+++ b/src/real-numbers/binary-minimum-real-numbers.lagda.md
@@ -243,3 +243,22 @@ abstract opaque
       ( neg-neg-ℝ x)
       ( neg-le-ℝ (le-max-le-le-ℝ (neg-le-ℝ x<y) (neg-le-ℝ x<z)))
 ```
+
+### The minimum with a constant real is an increasing map
+
+```agda
+is-increasing-min-ℝ :
+  {l1 l2 l3 : Level} →
+  (x : ℝ l1) →
+  (y : ℝ l2) →
+  (z : ℝ l3) →
+  leq-ℝ y z →
+  leq-ℝ (min-ℝ x y) (min-ℝ x z)
+is-increasing-min-ℝ x y z H =
+  leq-min-leq-leq-ℝ
+    ( x)
+    ( z)
+    ( min-ℝ x y)
+    ( leq-left-min-ℝ x y)
+    ( transitive-leq-ℝ _ _ _ H (leq-right-min-ℝ x y))
+```

--- a/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
+++ b/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
@@ -8,6 +8,7 @@ module real-numbers.clamp-function-closed-interval-real-numbers where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.function-types
 open import foundation.identity-types
 open import foundation.propositions
 open import foundation.universe-levels
@@ -26,6 +27,7 @@ open import real-numbers.metric-space-of-real-numbers
 open import real-numbers.short-map-binary-maximum-real-numbers
 open import real-numbers.short-map-binary-minimum-real-numbers
 open import real-numbers.similarity-real-numbers
+open import real-numbers.strict-inequality-real-numbers
 ```
 
 </details>
@@ -190,4 +192,46 @@ abstract
         ( [a,b])
         ( map-clamp-closed-interval-ℝ [a,b] x)
         ( is-in-closed-interval-map-clamp-closed-interval-ℝ [a,b] x))
+```
+
+### The clamping function is increasing
+
+```agda
+abstract
+  is-increasing-map-clamp-closed-interval-ℝ :
+      {l1 l2 l3 : Level} (I : closed-interval-ℝ l1 l2)
+      (x y : ℝ l3) →
+      leq-ℝ x y →
+      leq-ℝ
+        ( map-clamp-closed-interval-ℝ I x)
+        ( map-clamp-closed-interval-ℝ I y)
+  is-increasing-map-clamp-closed-interval-ℝ I x y =
+    is-increasing-max-ℝ
+      ( lower-bound-closed-interval-ℝ I)
+      ( min-ℝ (upper-bound-closed-interval-ℝ I) x)
+      ( min-ℝ (upper-bound-closed-interval-ℝ I) y) ∘
+    is-increasing-min-ℝ
+      ( upper-bound-closed-interval-ℝ I)
+      ( x)
+      ( y)
+```
+
+### For any `x y ∈ I`, if `x < y` then `clamp-I x < clamp-I y `
+
+```agda
+abstract
+  le-map-clamp-le-is-in-closed-interval-ℝ :
+    {l1 l2 l3 l4 : Level} (I : closed-interval-ℝ l1 l2) →
+    (x : ℝ l3) (Hx : is-in-closed-interval-ℝ I x) →
+    (y : ℝ l4) (Hy : is-in-closed-interval-ℝ I y) →
+    le-ℝ x y →
+    le-ℝ
+      ( map-clamp-closed-interval-ℝ I x)
+      ( map-clamp-closed-interval-ℝ I y)
+  le-map-clamp-le-is-in-closed-interval-ℝ I x Hx y Hy =
+    preserves-le-sim-ℝ
+      ( symmetric-sim-ℝ
+        ( clamp-is-in-closed-interval-ℝ I x Hx))
+      ( symmetric-sim-ℝ
+        ( clamp-is-in-closed-interval-ℝ I y Hy))
 ```

--- a/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
+++ b/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
@@ -11,6 +11,7 @@ open import foundation.dependent-pair-types
 open import foundation.function-types
 open import foundation.identity-types
 open import foundation.propositions
+open import foundation.subtypes
 open import foundation.universe-levels
 
 open import metric-spaces.closed-subsets-metric-spaces
@@ -123,13 +124,13 @@ short-map-clamp-closed-interval-ℝ [a,b] =
 
 ```agda
 abstract
-  clamp-leq-lower-bound-closed-interval-ℝ :
+  sim-clamp-leq-lower-bound-closed-interval-ℝ :
     {l1 l2 l3 : Level} ([a,b] : closed-interval-ℝ l1 l2) (x : ℝ l3) →
     leq-ℝ x (lower-bound-closed-interval-ℝ [a,b]) →
     sim-ℝ
       ( map-clamp-closed-interval-ℝ [a,b] x)
       ( lower-bound-closed-interval-ℝ [a,b])
-  clamp-leq-lower-bound-closed-interval-ℝ ((a , b) , a≤b) x x≤a =
+  sim-clamp-leq-lower-bound-closed-interval-ℝ ((a , b) , a≤b) x x≤a =
     similarity-reasoning-ℝ
       max-ℝ a (min-ℝ b x)
       ~ℝ max-ℝ a x
@@ -144,13 +145,13 @@ abstract
 
 ```agda
 abstract
-  clamp-leq-upper-bound-closed-interval-ℝ :
+  sim-clamp-leq-upper-bound-closed-interval-ℝ :
     {l1 l2 l3 : Level} ([a,b] : closed-interval-ℝ l1 l2) (x : ℝ l3) →
     leq-ℝ (upper-bound-closed-interval-ℝ [a,b]) x →
     sim-ℝ
       ( map-clamp-closed-interval-ℝ [a,b] x)
       ( upper-bound-closed-interval-ℝ [a,b])
-  clamp-leq-upper-bound-closed-interval-ℝ ((a , b) , a≤b) x b≤x =
+  sim-clamp-leq-upper-bound-closed-interval-ℝ ((a , b) , a≤b) x b≤x =
     similarity-reasoning-ℝ
       max-ℝ a (min-ℝ b x)
       ~ℝ max-ℝ a b
@@ -163,19 +164,29 @@ abstract
 
 ```agda
 abstract
-  clamp-is-in-closed-interval-ℝ :
+  sim-clamp-is-in-closed-interval-ℝ :
     {l1 l2 l3 : Level} ([a,b] : closed-interval-ℝ l1 l2) (x : ℝ l3) →
     is-in-closed-interval-ℝ [a,b] x →
     sim-ℝ
       ( map-clamp-closed-interval-ℝ [a,b] x)
       ( x)
-  clamp-is-in-closed-interval-ℝ ((a , b) , a≤b) x (a≤x , x≤b) =
+  sim-clamp-is-in-closed-interval-ℝ ((a , b) , a≤b) x (a≤x , x≤b) =
     similarity-reasoning-ℝ
       max-ℝ a (min-ℝ b x)
       ~ℝ max-ℝ a x
         by preserves-sim-right-max-ℝ _ _ _ (right-leq-left-min-ℝ x≤b)
       ~ℝ x
         by left-leq-right-max-ℝ a≤x
+
+  compute-clamp-in-closed-interval-ℝ :
+    {l l1 l2 : Level} (I : closed-interval-ℝ l1 l2)
+    (x : type-closed-interval-ℝ (l ⊔ l1 ⊔ l2) I) →
+    clamp-closed-interval-ℝ I (pr1 x) ＝ x
+  compute-clamp-in-closed-interval-ℝ I (x , x∈I) =
+    eq-type-subtype
+      ( subtype-closed-interval-ℝ _ I)
+      ( eq-sim-ℝ
+        ( sim-clamp-is-in-closed-interval-ℝ I x x∈I))
 ```
 
 ### The clamping function is idempotent
@@ -188,7 +199,7 @@ abstract
     map-clamp-closed-interval-ℝ [a,b] x
   is-idempotent-map-clamp-closed-interval-ℝ [a,b] x =
     eq-sim-ℝ
-      ( clamp-is-in-closed-interval-ℝ
+      ( sim-clamp-is-in-closed-interval-ℝ
         ( [a,b])
         ( map-clamp-closed-interval-ℝ [a,b] x)
         ( is-in-closed-interval-map-clamp-closed-interval-ℝ [a,b] x))
@@ -200,7 +211,7 @@ abstract
 abstract
   is-increasing-map-clamp-closed-interval-ℝ :
       {l1 l2 l3 l4 : Level} (I : closed-interval-ℝ l1 l2)
-      (x : ℝ l3) →
+      (x : ℝ l3)
       (y : ℝ l4) →
       leq-ℝ x y →
       leq-ℝ
@@ -232,7 +243,28 @@ abstract
   le-map-clamp-le-is-in-closed-interval-ℝ I x Hx y Hy =
     preserves-le-sim-ℝ
       ( symmetric-sim-ℝ
-        ( clamp-is-in-closed-interval-ℝ I x Hx))
+        ( sim-clamp-is-in-closed-interval-ℝ I x Hx))
       ( symmetric-sim-ℝ
-        ( clamp-is-in-closed-interval-ℝ I y Hy))
+        ( sim-clamp-is-in-closed-interval-ℝ I y Hy))
+```
+
+### The clamp function preserves similarity
+
+```agda
+sim-clamp-closed-interval-ℝ :
+    {l1 l2 l3 l4 : Level} (I : closed-interval-ℝ l1 l2) →
+    (x : ℝ l3) →
+    (y : ℝ l4) →
+    sim-ℝ x y →
+    sim-ℝ
+      ( map-clamp-closed-interval-ℝ I x)
+      ( map-clamp-closed-interval-ℝ I y)
+sim-clamp-closed-interval-ℝ I x y x~y =
+  sim-antisymmetric-leq-ℝ
+    ( map-clamp-closed-interval-ℝ I x)
+    ( map-clamp-closed-interval-ℝ I y)
+    ( is-increasing-map-clamp-closed-interval-ℝ I x y
+      ( leq-sim-ℝ x~y))
+    ( is-increasing-map-clamp-closed-interval-ℝ I y x
+      ( leq-sim-ℝ' x~y))
 ```

--- a/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
+++ b/src/real-numbers/clamp-function-closed-interval-real-numbers.lagda.md
@@ -199,8 +199,9 @@ abstract
 ```agda
 abstract
   is-increasing-map-clamp-closed-interval-ℝ :
-      {l1 l2 l3 : Level} (I : closed-interval-ℝ l1 l2)
-      (x y : ℝ l3) →
+      {l1 l2 l3 l4 : Level} (I : closed-interval-ℝ l1 l2)
+      (x : ℝ l3) →
+      (y : ℝ l4) →
       leq-ℝ x y →
       leq-ℝ
         ( map-clamp-closed-interval-ℝ I x)

--- a/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/proper-closed-intervals-real-numbers.lagda.md
@@ -21,9 +21,12 @@ open import elementary-number-theory.unit-fractions-rational-numbers
 
 open import foundation.cartesian-product-types
 open import foundation.conjunction
+open import foundation.coproduct-types
 open import foundation.dependent-pair-types
+open import foundation.dependent-products-propositions
 open import foundation.disjunction
 open import foundation.existential-quantification
+open import foundation.function-types
 open import foundation.identity-types
 open import foundation.inhabited-subtypes
 open import foundation.propositional-truncations
@@ -264,6 +267,12 @@ clamp-proper-closed-interval-ℝ :
   type-proper-closed-interval-ℝ (l1 ⊔ l2 ⊔ l3) [a,b]
 clamp-proper-closed-interval-ℝ [a,b] =
   clamp-closed-interval-ℝ (closed-interval-proper-closed-interval-ℝ [a,b])
+
+map-clamp-proper-closed-interval-ℝ :
+  {l1 l2 l3 : Level} ([a,b] : proper-closed-interval-ℝ l1 l2) → ℝ l3 →
+  ℝ (l1 ⊔ l2 ⊔ l3)
+map-clamp-proper-closed-interval-ℝ [a,b] =
+  map-clamp-closed-interval-ℝ (closed-interval-proper-closed-interval-ℝ [a,b])
 ```
 
 ### The clamp function is a short map
@@ -1016,4 +1025,84 @@ module _
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ))
       ( sim-raise-ℝ l1 _)
       ( sim-raise-ℝ l _)
+```
+
+### Location of strictly ordered pairs of rational numbers w.r.t. a proper closed interval
+
+For any proper closed interval `[a,b]` and any pair `(p q : ℚ)` with `p < q`
+then one of the following propositions holds:
+
+- `p < a`;
+- `b < q`;
+- `∃ (r s : ℚ) | (a < r < s < b) ∧ (p < r) ∧ (s < q)`, i.e. `[r, s]` is a proper
+  sub-interval of both `[a, b] ∩ [p, q]`.
+
+```agda
+module _
+  {l1 l2 : Level} (I : proper-closed-interval-ℝ l1 l2)
+  (p q : ℚ) (H : le-ℚ p q)
+  where
+
+  trichotomy-prop-le-rational-proper-closed-interval-ℝ : Prop (l1 ⊔ l2)
+  trichotomy-prop-le-rational-proper-closed-interval-ℝ =
+    ( lower-cut-ℝ (lower-bound-proper-closed-interval-ℝ I) p) ∨
+    ( upper-cut-ℝ (upper-bound-proper-closed-interval-ℝ I) q) ∨
+    ( ∃ ( ℚ)
+        ( λ r →
+          ∃ ( ℚ)
+            ( λ s →
+              ( upper-cut-ℝ
+                ( lower-bound-proper-closed-interval-ℝ I)
+                ( r)) ∧
+              ( lower-cut-ℝ
+                ( upper-bound-proper-closed-interval-ℝ I)
+                ( s)) ∧
+              ( le-ℚ-Prop r s) ∧
+              ( le-ℚ-Prop p r) ∧
+              ( le-ℚ-Prop s q))))
+
+  trichotomy-le-rational-proper-closed-interval-ℝ : UU (l1 ⊔ l2)
+  trichotomy-le-rational-proper-closed-interval-ℝ =
+    type-Prop trichotomy-prop-le-rational-proper-closed-interval-ℝ
+
+  is-prop-trichotomy-le-rational-proper-closed-interval-ℝ :
+    is-prop trichotomy-le-rational-proper-closed-interval-ℝ
+  is-prop-trichotomy-le-rational-proper-closed-interval-ℝ =
+    is-prop-type-Prop trichotomy-prop-le-rational-proper-closed-interval-ℝ
+
+  lemma-trichotomy-le-rational-proper-closed-interval-ℝ :
+    trichotomy-le-rational-proper-closed-interval-ℝ
+  lemma-trichotomy-le-rational-proper-closed-interval-ℝ =
+    let
+      open
+        do-syntax-trunc-Prop
+          trichotomy-prop-le-rational-proper-closed-interval-ℝ
+    in do
+      (r , p<r , r<q) ← dense-le-ℚ H
+      (s , r<s , s<q) ← dense-le-ℚ r<q
+      locate-a ←
+        is-located-lower-upper-cut-ℝ
+          ( lower-bound-proper-closed-interval-ℝ I)
+          ( p<r)
+
+      locate-b ←
+        is-located-lower-upper-cut-ℝ
+          ( upper-bound-proper-closed-interval-ℝ I)
+          ( s<q)
+
+      rec-coproduct
+        ( unit-trunc-Prop ∘ inl)
+        ( λ lo →
+          rec-coproduct
+            ( λ hi →
+              unit-trunc-Prop
+                ( inr
+                  ( unit-trunc-Prop
+                    ( inr
+                      ( intro-exists r
+                        ( intro-exists s
+                          ( lo , hi , r<s , p<r , s<q)))))))
+            ( unit-trunc-Prop ∘ inr ∘ unit-trunc-Prop ∘ inl)
+            ( locate-b))
+        ( locate-a)
 ```

--- a/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
+++ b/src/real-numbers/strictly-increasing-real-maps-proper-closed-intervals-real-numbers.lagda.md
@@ -182,34 +182,35 @@ module _
   (I : proper-closed-interval-ℝ l3 l4)
   (f : real-map-proper-closed-interval-ℝ (l1 ⊔ l3 ⊔ l4) l2 I)
   (H : is-strictly-increasing-real-map-proper-closed-interval-ℝ I f)
-  where abstract
+  where
 
-  le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
-    le-ℝ
-      ( f
+  abstract
+    le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
+      le-ℝ
+        ( f
+          ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1)))
+        ( f
+          ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1)))
+    le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
+      H
         ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
           ( I)
-          ( l1)))
-      ( f
+          ( l1))
         ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
           ( I)
-          ( l1)))
-  le-im-bounds-is-strictly-increasing-real-map-proper-closed-interval-ℝ =
-    H
-      ( raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-        ( I)
-        ( l1))
-      ( raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-        ( I)
-        ( l1))
-      ( preserves-le-sim-ℝ
-        ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
-          ( I)
           ( l1))
-        ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
-          ( I)
-          ( l1))
-        ( le-bounds-proper-closed-interval-ℝ I))
+        ( preserves-le-sim-ℝ
+          ( sim-raise-in-proper-closed-interval-lower-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1))
+          ( sim-raise-in-proper-closed-interval-upper-bound-proper-closed-interval-ℝ
+            ( I)
+            ( l1))
+          ( le-bounds-proper-closed-interval-ℝ I))
 
   proper-closed-interval-im-is-strictly-increasing-real-map-proper-closed-interval-ℝ :
     proper-closed-interval-ℝ l2 l2


### PR DESCRIPTION
This PR introduces a few lemmas on the min/max/clamp functions on real numbers:

- for any `x : ℝ`, the functions `max-ℝ x` and `min-ℝ x` are _increasing_;
- for any closed interval `I`, the clamping map `clamp-I` is _increasing_ and _strictly increasing_ on `I`;

We also prove the following location property for proper closed intervals: for any proper closed interval `[a, b]` and rational numbers `p < q`, then either:

- `p < a`;
- `q < b`;
- there exists `(s r : ℚ)` such that `a < s < r < b` and `p < s < r < q`.