### PR TITLE
Rounded lower/upper subsets of ℚ

### DIFF
--- a/src/elementary-number-theory.lagda.md
+++ b/src/elementary-number-theory.lagda.md
@@ -207,6 +207,8 @@ open import elementary-number-theory.retracts-of-natural-numbers public
 open import elementary-number-theory.ring-extension-rational-numbers-of-rational-numbers public
 open import elementary-number-theory.ring-of-integers public
 open import elementary-number-theory.ring-of-rational-numbers public
+open import elementary-number-theory.rounded-lower-subsets-rational-numbers public
+open import elementary-number-theory.rounded-upper-subsets-rational-numbers public
 open import elementary-number-theory.semiring-of-natural-numbers public
 open import elementary-number-theory.series-rational-numbers public
 open import elementary-number-theory.sieve-of-eratosthenes public

--- a/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
@@ -63,6 +63,34 @@ module _
     is-prop-type-Prop is-rounded-prop-lower-type-ℚ
 ```
 
+### The type of rounded lower subsets of `ℚ`
+
+```agda
+rounded-lower-type-ℚ : (l : Level) → UU (lsuc l)
+rounded-lower-type-ℚ l =
+  type-subtype (is-rounded-prop-lower-type-ℚ {l})
+
+module _
+  {l : Level} (L : rounded-lower-type-ℚ l)
+  where
+
+  lower-type-rounded-lower-type-ℚ : lower-type-Preorder l ℚ-Preorder
+  lower-type-rounded-lower-type-ℚ = pr1 L
+
+  subtype-rounded-lower-type-ℚ : subtype l ℚ
+  subtype-rounded-lower-type-ℚ = pr1 lower-type-rounded-lower-type-ℚ
+
+  is-downwards-rounded-lower-type-ℚ :
+    is-downwards-closed-subtype-Preorder
+      ( ℚ-Preorder)
+      ( subtype-rounded-lower-type-ℚ)
+  is-downwards-rounded-lower-type-ℚ = pr2 lower-type-rounded-lower-type-ℚ
+
+  is-rounded-lower-type-rounded-lower-type-ℚ :
+    is-rounded-lower-type-ℚ lower-type-rounded-lower-type-ℚ
+  is-rounded-lower-type-rounded-lower-type-ℚ = pr2 L
+```
+
 ## Properties
 
 ### Any lower subset can be rounded
@@ -107,9 +135,15 @@ module _
 
         intro-exists s (r<s , intro-exists q (s<q , Lq))
 
-    leq-subtype-round-lower-type :
+  round-lower-type-ℚ : rounded-lower-type-ℚ l
+  round-lower-type-ℚ =
+    ( lower-subtype-round-lower-type-ℚ ,
+      is-rounded-lower-subtype-round-lower-type-ℚ)
+
+  abstract
+    leq-subtype-round-lower-type-ℚ :
       subtype-round-lower-type-ℚ ⊆ subtype-lower-type-Preorder ℚ-Preorder L
-    leq-subtype-round-lower-type q =
+    leq-subtype-round-lower-type-ℚ q =
       elim-exists
         ( subtype-lower-type-Preorder ℚ-Preorder L q)
         ( λ r (q<r , Lr) →

--- a/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
@@ -1,0 +1,123 @@
+# Rounded lower subsets of raional numbers
+
+```agda
+module elementary-number-theory.rounded-lower-subsets-rational-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.inequality-rational-numbers
+open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.strict-inequality-rational-numbers
+
+open import foundation.conjunction
+open import foundation.dependent-pair-types
+open import foundation.dependent-products-propositions
+open import foundation.existential-quantification
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import order-theory.lower-types-preorders
+open import order-theory.preorders
+```
+
+</details>
+
+## Idea
+
+A [lower subset](order-theory.lower-types-preorders.md) `L` of
+[rational numbers](elementary-number-theory.rational-numbers.md) is
+{{#concept "rounded" Disambiguation"lower subset of rational numbers"}} if for
+any `q ∈ L`, there [exists](foundation.existential-quantification.md) `(r : ℚ)`
+such that `q < r` and `r ∈ L`.
+
+## Definitions
+
+### The property of being a rounded lower subset of rational numbers
+
+```agda
+module _
+  {l : Level}
+  (L : lower-type-Preorder l ℚ-Preorder)
+  where
+
+  is-rounded-prop-lower-type-ℚ : Prop l
+  is-rounded-prop-lower-type-ℚ =
+    Π-Prop
+      ( ℚ)
+      ( λ q →
+        subtype-lower-type-Preorder ℚ-Preorder L q ⇒
+        ∃ ( ℚ)
+          ( λ r →
+            ( le-ℚ-Prop q r) ∧
+            ( subtype-lower-type-Preorder ℚ-Preorder L r)))
+
+  is-rounded-lower-type-ℚ : UU l
+  is-rounded-lower-type-ℚ = type-Prop is-rounded-prop-lower-type-ℚ
+
+  is-prop-is-rounded-lower-type-ℚ : is-prop is-rounded-lower-type-ℚ
+  is-prop-is-rounded-lower-type-ℚ =
+    is-prop-type-Prop is-rounded-prop-lower-type-ℚ
+```
+
+## Properties
+
+### Any lower subset can be rounded
+
+```agda
+module _
+  {l : Level}
+  (L : lower-type-Preorder l ℚ-Preorder)
+  where
+
+  subtype-round-lower-type-ℚ : subtype l ℚ
+  subtype-round-lower-type-ℚ r =
+    ∃ ( ℚ)
+      ( λ q →
+        ( le-ℚ-Prop r q) ∧
+        ( subtype-lower-type-Preorder ℚ-Preorder L q))
+
+  abstract
+    is-lower-subtype-round-lower-type-ℚ :
+      is-downwards-closed-subtype-Preorder ℚ-Preorder subtype-round-lower-type-ℚ
+    is-lower-subtype-round-lower-type-ℚ q r H =
+      elim-exists
+        ( subtype-round-lower-type-ℚ r)
+        ( λ s (q<s , Ls) →
+          intro-exists s (concatenate-leq-le-ℚ _ _ _ H q<s , Ls))
+
+  lower-subtype-round-lower-type-ℚ : lower-type-Preorder l ℚ-Preorder
+  lower-subtype-round-lower-type-ℚ =
+    ( subtype-round-lower-type-ℚ , is-lower-subtype-round-lower-type-ℚ)
+
+  abstract
+    is-rounded-lower-subtype-round-lower-type-ℚ :
+      is-rounded-lower-type-ℚ lower-subtype-round-lower-type-ℚ
+    is-rounded-lower-subtype-round-lower-type-ℚ r Lr =
+      let
+        open
+          do-syntax-trunc-Prop
+            ( ∃ ℚ (λ q → le-ℚ-Prop r q ∧ subtype-round-lower-type-ℚ q))
+      in do
+        ( q , r<q , Lq) ← Lr
+        ( s , r<s , s<q) ← dense-le-ℚ r<q
+
+        intro-exists s (r<s , intro-exists q (s<q , Lq))
+
+    leq-subtype-round-lower-type :
+      subtype-round-lower-type-ℚ ⊆ subtype-lower-type-Preorder ℚ-Preorder L
+    leq-subtype-round-lower-type q =
+      elim-exists
+        ( subtype-lower-type-Preorder ℚ-Preorder L q)
+        ( λ r (q<r , Lr) →
+          is-downwards-closed-lower-type-Preorder
+            ( ℚ-Preorder)
+            ( L)
+            ( r)
+            ( q)
+            ( leq-le-ℚ q<r)
+            ( Lr))
+```

--- a/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
@@ -189,3 +189,21 @@ is-idempotent-round-lower-type-ℚ L =
       ( lower-subtype-round-lower-type-ℚ L)
       ( is-rounded-lower-subtype-round-lower-type-ℚ L))
 ```
+
+### The rounding of a lower subset is its maximal rounded lower subset
+
+```agda
+is-maximal-round-lower-type-ℚ :
+  {l : Level} (L : lower-type-Preorder l ℚ-Preorder) →
+  {l1 : Level} (S : lower-type-Preorder l1 ℚ-Preorder) →
+  is-rounded-lower-type-ℚ S →
+  ( subtype-lower-type-Preorder ℚ-Preorder S ⊆
+    subtype-lower-type-Preorder ℚ-Preorder L) →
+  ( subtype-lower-type-Preorder ℚ-Preorder S ⊆
+    subtype-round-lower-type-ℚ L)
+is-maximal-round-lower-type-ℚ L S H S⊆L x x∈S =
+  elim-exists
+    ( subtype-round-lower-type-ℚ L x)
+    ( λ y (x<y , y∈S) → intro-exists y (x<y , S⊆L y y∈S))
+    ( H x x∈S)
+```

--- a/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-lower-subsets-rational-numbers.lagda.md
@@ -15,6 +15,8 @@ open import foundation.conjunction
 open import foundation.dependent-pair-types
 open import foundation.dependent-products-propositions
 open import foundation.existential-quantification
+open import foundation.idempotent-maps
+open import foundation.identity-types
 open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.subtypes
@@ -154,4 +156,36 @@ module _
             ( q)
             ( leq-le-ℚ q<r)
             ( Lr))
+```
+
+### Rounding a rounded lower subtype is the identity
+
+```agda
+module _
+  {l : Level}
+  (L : lower-type-Preorder l ℚ-Preorder)
+  (rounded-L : is-rounded-lower-type-ℚ L)
+  where
+
+  compute-round-is-rounded-lower-type-ℚ :
+    subtype-round-lower-type-ℚ L ＝ subtype-lower-type-Preorder ℚ-Preorder L
+  compute-round-is-rounded-lower-type-ℚ =
+    eq-has-same-elements-subtype
+      ( subtype-round-lower-type-ℚ L)
+      ( subtype-lower-type-Preorder ℚ-Preorder L)
+      ( λ q → leq-subtype-round-lower-type-ℚ L q , rounded-L q)
+```
+
+### Rounding a lower subset of rational numbers is idempotent
+
+```agda
+is-idempotent-round-lower-type-ℚ :
+  {l : Level} →
+  is-idempotent (lower-subtype-round-lower-type-ℚ {l})
+is-idempotent-round-lower-type-ℚ L =
+  eq-type-subtype
+    ( is-downwards-closed-prop-subtype-Preorder ℚ-Preorder)
+    ( compute-round-is-rounded-lower-type-ℚ
+      ( lower-subtype-round-lower-type-ℚ L)
+      ( is-rounded-lower-subtype-round-lower-type-ℚ L))
 ```

--- a/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
@@ -63,6 +63,34 @@ module _
     is-prop-type-Prop is-rounded-prop-upper-type-ℚ
 ```
 
+### The type of rounded upper subsets of `ℚ`
+
+```agda
+rounded-upper-type-ℚ : (l : Level) → UU (lsuc l)
+rounded-upper-type-ℚ l =
+  type-subtype (is-rounded-prop-upper-type-ℚ {l})
+
+module _
+  {l : Level} (L : rounded-upper-type-ℚ l)
+  where
+
+  upper-type-rounded-upper-type-ℚ : upper-type-Preorder l ℚ-Preorder
+  upper-type-rounded-upper-type-ℚ = pr1 L
+
+  subtype-rounded-upper-type-ℚ : subtype l ℚ
+  subtype-rounded-upper-type-ℚ = pr1 upper-type-rounded-upper-type-ℚ
+
+  is-upwards-rounded-upper-type-ℚ :
+    is-upwards-closed-subtype-Preorder
+      ( ℚ-Preorder)
+      ( subtype-rounded-upper-type-ℚ)
+  is-upwards-rounded-upper-type-ℚ = pr2 upper-type-rounded-upper-type-ℚ
+
+  is-rounded-upper-type-rounded-upper-type-ℚ :
+    is-rounded-upper-type-ℚ upper-type-rounded-upper-type-ℚ
+  is-rounded-upper-type-rounded-upper-type-ℚ = pr2 L
+```
+
 ## Properties
 
 ### Any upper subset can be rounded
@@ -107,9 +135,15 @@ module _
 
         intro-exists s (s<r , intro-exists q (q<s , Uq))
 
-    leq-subtype-round-upper-type :
+  round-upper-type-ℚ : rounded-upper-type-ℚ l
+  round-upper-type-ℚ =
+    ( upper-subtype-round-upper-type-ℚ ,
+      is-rounded-upper-subtype-round-upper-type-ℚ)
+
+  abstract
+    leq-subtype-round-upper-type-ℚ :
       subtype-round-upper-type-ℚ ⊆ subtype-upper-type-Preorder ℚ-Preorder U
-    leq-subtype-round-upper-type q =
+    leq-subtype-round-upper-type-ℚ q =
       elim-exists
         ( subtype-upper-type-Preorder ℚ-Preorder U q)
         ( λ r (r<q , Ur) →

--- a/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
@@ -189,3 +189,21 @@ is-idempotent-round-upper-type-ℚ L =
       ( upper-subtype-round-upper-type-ℚ L)
       ( is-rounded-upper-subtype-round-upper-type-ℚ L))
 ```
+
+### The rounding of an upper subset is its maximal rounded upper subset
+
+```agda
+is-minimal-round-upper-type-ℚ :
+  {l : Level} (L : upper-type-Preorder l ℚ-Preorder) →
+  {l1 : Level} (S : upper-type-Preorder l1 ℚ-Preorder) →
+  is-rounded-upper-type-ℚ S →
+  ( subtype-upper-type-Preorder ℚ-Preorder S ⊆
+    subtype-upper-type-Preorder ℚ-Preorder L) →
+  ( subtype-upper-type-Preorder ℚ-Preorder S ⊆
+    subtype-round-upper-type-ℚ L)
+is-minimal-round-upper-type-ℚ L S H S⊆L x x∈S =
+  elim-exists
+    ( subtype-round-upper-type-ℚ L x)
+    ( λ y (y<x , y∈S) → intro-exists y (y<x , S⊆L y y∈S))
+    ( H x x∈S)
+```

--- a/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
@@ -1,0 +1,123 @@
+# Rounded upper subsets of raional numbers
+
+```agda
+module elementary-number-theory.rounded-upper-subsets-rational-numbers where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import elementary-number-theory.inequality-rational-numbers
+open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.strict-inequality-rational-numbers
+
+open import foundation.conjunction
+open import foundation.dependent-pair-types
+open import foundation.dependent-products-propositions
+open import foundation.existential-quantification
+open import foundation.propositional-truncations
+open import foundation.propositions
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import order-theory.preorders
+open import order-theory.upper-types-preorders
+```
+
+</details>
+
+## Idea
+
+An [upper subset](order-theory.upper-types-preorders.md) `L` of
+[rational numbers](elementary-number-theory.rational-numbers.md) is
+{{#concept "rounded" Disambiguation"upper subset of rational numbers"}} if for
+any `q ∈ U`, there [exists](foundation.existential-quantification.md) `(r : ℚ)`
+such that `r < q` and `r ∈ U`.
+
+## Definitions
+
+### The property of being a rounded upper subset of rational numbers
+
+```agda
+module _
+  {l : Level}
+  (U : upper-type-Preorder l ℚ-Preorder)
+  where
+
+  is-rounded-prop-upper-type-ℚ : Prop l
+  is-rounded-prop-upper-type-ℚ =
+    Π-Prop
+      ( ℚ)
+      ( λ q →
+        subtype-upper-type-Preorder ℚ-Preorder U q ⇒
+        ∃ ( ℚ)
+          ( λ s →
+            ( le-ℚ-Prop s q) ∧
+            ( subtype-upper-type-Preorder ℚ-Preorder U s)))
+
+  is-rounded-upper-type-ℚ : UU l
+  is-rounded-upper-type-ℚ = type-Prop is-rounded-prop-upper-type-ℚ
+
+  is-prop-is-rounded-upper-type-ℚ : is-prop is-rounded-upper-type-ℚ
+  is-prop-is-rounded-upper-type-ℚ =
+    is-prop-type-Prop is-rounded-prop-upper-type-ℚ
+```
+
+## Properties
+
+### Any upper subset can be rounded
+
+```agda
+module _
+  {l : Level}
+  (U : upper-type-Preorder l ℚ-Preorder)
+  where
+
+  subtype-round-upper-type-ℚ : subtype l ℚ
+  subtype-round-upper-type-ℚ r =
+    ∃ ( ℚ)
+      ( λ q →
+        ( le-ℚ-Prop q r) ∧
+        ( subtype-upper-type-Preorder ℚ-Preorder U q))
+
+  abstract
+    is-upper-subtype-round-upper-type-ℚ :
+      is-upwards-closed-subtype-Preorder ℚ-Preorder subtype-round-upper-type-ℚ
+    is-upper-subtype-round-upper-type-ℚ q r H =
+      elim-exists
+        ( subtype-round-upper-type-ℚ r)
+        ( λ s (s<r , Ur) →
+          intro-exists s (concatenate-le-leq-ℚ _ _ _ s<r H , Ur))
+
+  upper-subtype-round-upper-type-ℚ : upper-type-Preorder l ℚ-Preorder
+  upper-subtype-round-upper-type-ℚ =
+    ( subtype-round-upper-type-ℚ , is-upper-subtype-round-upper-type-ℚ)
+
+  abstract
+    is-rounded-upper-subtype-round-upper-type-ℚ :
+      is-rounded-upper-type-ℚ upper-subtype-round-upper-type-ℚ
+    is-rounded-upper-subtype-round-upper-type-ℚ r Ur =
+      let
+        open
+          do-syntax-trunc-Prop
+            ( ∃ ℚ (λ q → le-ℚ-Prop q r ∧ subtype-round-upper-type-ℚ q))
+      in do
+        ( q , q<r , Uq) ← Ur
+        ( s , q<s , s<r) ← dense-le-ℚ q<r
+
+        intro-exists s (s<r , intro-exists q (q<s , Uq))
+
+    leq-subtype-round-upper-type :
+      subtype-round-upper-type-ℚ ⊆ subtype-upper-type-Preorder ℚ-Preorder U
+    leq-subtype-round-upper-type q =
+      elim-exists
+        ( subtype-upper-type-Preorder ℚ-Preorder U q)
+        ( λ r (r<q , Ur) →
+          is-upwards-closed-upper-type-Preorder
+            ( ℚ-Preorder)
+            ( U)
+            ( r)
+            ( q)
+            ( leq-le-ℚ r<q)
+            ( Ur))
+```

--- a/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
+++ b/src/elementary-number-theory/rounded-upper-subsets-rational-numbers.lagda.md
@@ -15,6 +15,8 @@ open import foundation.conjunction
 open import foundation.dependent-pair-types
 open import foundation.dependent-products-propositions
 open import foundation.existential-quantification
+open import foundation.idempotent-maps
+open import foundation.identity-types
 open import foundation.propositional-truncations
 open import foundation.propositions
 open import foundation.subtypes
@@ -154,4 +156,36 @@ module _
             ( q)
             ( leq-le-ℚ r<q)
             ( Ur))
+```
+
+### Rounding a rounded upper subtype is the identity
+
+```agda
+module _
+  {l : Level}
+  (L : upper-type-Preorder l ℚ-Preorder)
+  (rounded-L : is-rounded-upper-type-ℚ L)
+  where
+
+  compute-round-is-rounded-upper-type-ℚ :
+    subtype-round-upper-type-ℚ L ＝ subtype-upper-type-Preorder ℚ-Preorder L
+  compute-round-is-rounded-upper-type-ℚ =
+    eq-has-same-elements-subtype
+      ( subtype-round-upper-type-ℚ L)
+      ( subtype-upper-type-Preorder ℚ-Preorder L)
+      ( λ q → leq-subtype-round-upper-type-ℚ L q , rounded-L q)
+```
+
+### Rounding an upper subset of rational numbers is idempotent
+
+```agda
+is-idempotent-round-upper-type-ℚ :
+  {l : Level} →
+  is-idempotent (upper-subtype-round-upper-type-ℚ {l})
+is-idempotent-round-upper-type-ℚ L =
+  eq-type-subtype
+    ( is-upwards-closed-prop-subtype-Preorder ℚ-Preorder)
+    ( compute-round-is-rounded-upper-type-ℚ
+      ( upper-subtype-round-upper-type-ℚ L)
+      ( is-rounded-upper-subtype-round-upper-type-ℚ L))
 ```

--- a/src/order-theory.lagda.md
+++ b/src/order-theory.lagda.md
@@ -173,6 +173,7 @@ open import order-theory.upper-bounds-chains-posets public
 open import order-theory.upper-bounds-large-posets public
 open import order-theory.upper-bounds-posets public
 open import order-theory.upper-sets-large-posets public
+open import order-theory.upper-types-preorders public
 open import order-theory.well-founded-relations public
 open import order-theory.zorns-lemma public
 ```

--- a/src/order-theory/lower-types-preorders.lagda.md
+++ b/src/order-theory/lower-types-preorders.lagda.md
@@ -8,6 +8,8 @@ module order-theory.lower-types-preorders where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.dependent-products-propositions
+open import foundation.propositions
 open import foundation.subtypes
 open import foundation.universe-levels
 
@@ -27,11 +29,20 @@ module _
   {l1 l2 : Level} (P : Preorder l1 l2)
   where
 
+  is-downwards-closed-prop-subtype-Preorder :
+    {l3 : Level} (S : subtype l3 (type-Preorder P)) → Prop (l1 ⊔ l2 ⊔ l3)
+  is-downwards-closed-prop-subtype-Preorder S =
+    Π-Prop
+      ( type-Preorder P)
+      ( λ x →
+        Π-Prop
+          ( type-Preorder P)
+          ( λ y → leq-prop-Preorder P y x ⇒ S x ⇒ S y))
+
   is-downwards-closed-subtype-Preorder :
     {l3 : Level} (S : subtype l3 (type-Preorder P)) → UU (l1 ⊔ l2 ⊔ l3)
   is-downwards-closed-subtype-Preorder S =
-    (x y : type-Preorder P) →
-    leq-Preorder P y x → is-in-subtype S x → is-in-subtype S y
+    type-Prop (is-downwards-closed-prop-subtype-Preorder S)
 
 lower-type-Preorder :
   {l1 l2 : Level} (l3 : Level) → Preorder l1 l2 → UU (l1 ⊔ l2 ⊔ lsuc l3)

--- a/src/order-theory/lower-types-preorders.lagda.md
+++ b/src/order-theory/lower-types-preorders.lagda.md
@@ -48,6 +48,10 @@ module _
   type-lower-type-Preorder : UU (l1 ⊔ l3)
   type-lower-type-Preorder = type-subtype subtype-lower-type-Preorder
 
+  is-downwards-closed-lower-type-Preorder :
+    is-downwards-closed-subtype-Preorder P subtype-lower-type-Preorder
+  is-downwards-closed-lower-type-Preorder = pr2 L
+
   inclusion-lower-type-Preorder :
     type-lower-type-Preorder → type-Preorder P
   inclusion-lower-type-Preorder = pr1

--- a/src/order-theory/upper-types-preorders.lagda.md
+++ b/src/order-theory/upper-types-preorders.lagda.md
@@ -1,0 +1,65 @@
+# Upper types in preorders
+
+```agda
+module order-theory.upper-types-preorders where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.subtypes
+open import foundation.universe-levels
+
+open import order-theory.lower-types-preorders
+open import order-theory.opposite-preorders
+open import order-theory.preorders
+```
+
+</details>
+
+## Idea
+
+An **upper type** in a preorder `P` is a upwards closed subtype of `P`.
+
+## Definition
+
+```agda
+is-upwards-closed-subtype-Preorder :
+  {l1 l2 : Level} (P : Preorder l1 l2) {l3 : Level}
+  (S : subtype l3 (type-Preorder P)) →
+  UU (l1 ⊔ l2 ⊔ l3)
+is-upwards-closed-subtype-Preorder P =
+  is-downwards-closed-subtype-Preorder
+    ( opposite-Preorder P)
+
+upper-type-Preorder :
+  {l1 l2 : Level} (l3 : Level) → Preorder l1 l2 → UU (l1 ⊔ l2 ⊔ lsuc l3)
+upper-type-Preorder l3 P =
+  Σ (subtype l3 (type-Preorder P))
+    (is-upwards-closed-subtype-Preorder P)
+
+module _
+  {l1 l2 l3 : Level} (P : Preorder l1 l2) (L : upper-type-Preorder l3 P)
+  where
+
+  subtype-upper-type-Preorder : subtype l3 (type-Preorder P)
+  subtype-upper-type-Preorder = pr1 L
+
+  type-upper-type-Preorder : UU (l1 ⊔ l3)
+  type-upper-type-Preorder = type-subtype subtype-upper-type-Preorder
+
+  is-upwards-closed-upper-type-Preorder :
+    is-upwards-closed-subtype-Preorder P (subtype-upper-type-Preorder)
+  is-upwards-closed-upper-type-Preorder = pr2 L
+
+  inclusion-upper-type-Preorder :
+    type-upper-type-Preorder → type-Preorder P
+  inclusion-upper-type-Preorder = pr1
+
+  leq-upper-type-Preorder : (x y : type-upper-type-Preorder) → UU l2
+  leq-upper-type-Preorder x y =
+    leq-Preorder P
+      ( inclusion-upper-type-Preorder x)
+      ( inclusion-upper-type-Preorder y)
+```

--- a/src/order-theory/upper-types-preorders.lagda.md
+++ b/src/order-theory/upper-types-preorders.lagda.md
@@ -8,6 +8,8 @@ module order-theory.upper-types-preorders where
 
 ```agda
 open import foundation.dependent-pair-types
+open import foundation.dependent-products-propositions
+open import foundation.propositions
 open import foundation.subtypes
 open import foundation.universe-levels
 
@@ -25,6 +27,14 @@ An **upper type** in a preorder `P` is a upwards closed subtype of `P`.
 ## Definition
 
 ```agda
+is-upwards-closed-prop-subtype-Preorder :
+  {l1 l2 : Level} (P : Preorder l1 l2) {l3 : Level}
+  (S : subtype l3 (type-Preorder P)) →
+  Prop (l1 ⊔ l2 ⊔ l3)
+is-upwards-closed-prop-subtype-Preorder P =
+  is-downwards-closed-prop-subtype-Preorder
+    ( opposite-Preorder P)
+
 is-upwards-closed-subtype-Preorder :
   {l1 l2 : Level} (P : Preorder l1 l2) {l3 : Level}
   (S : subtype l3 (type-Preorder P)) →

--- a/src/real-numbers/lower-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/lower-dedekind-real-numbers.lagda.md
@@ -15,6 +15,7 @@ open import elementary-number-theory.difference-rational-numbers
 open import elementary-number-theory.inequality-rational-numbers
 open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.rounded-lower-subsets-rational-numbers
 open import elementary-number-theory.strict-inequality-rational-numbers
 
 open import foundation.conjunction
@@ -25,6 +26,7 @@ open import foundation.dependent-products-truncated-types
 open import foundation.existential-quantification
 open import foundation.function-types
 open import foundation.identity-types
+open import foundation.inhabited-subtypes
 open import foundation.logical-equivalences
 open import foundation.propositions
 open import foundation.sets
@@ -185,6 +187,30 @@ module _
   eq-sim-cut-lower-ℝ : sim-subtype (cut-lower-ℝ x) (cut-lower-ℝ y) → x ＝ y
   eq-sim-cut-lower-ℝ =
     eq-eq-cut-lower-ℝ ∘ eq-sim-subtype (cut-lower-ℝ x) (cut-lower-ℝ y)
+```
+
+### Any inhabited rounded lower subset of rational numbers defines a lower real
+
+```agda
+module _
+  {l : Level}
+  (L : rounded-lower-type-ℚ l)
+  (H : is-inhabited-subtype (subtype-rounded-lower-type-ℚ L))
+  where
+
+  lower-real-is-inhabited-rounded-lower-type-ℚ : lower-ℝ l
+  pr1 lower-real-is-inhabited-rounded-lower-type-ℚ =
+    subtype-rounded-lower-type-ℚ L
+  pr2 lower-real-is-inhabited-rounded-lower-type-ℚ =
+    ( H ,
+      λ q →
+        ( is-rounded-lower-type-rounded-lower-type-ℚ L q ,
+          elim-exists
+            ( subtype-rounded-lower-type-ℚ L q)
+            ( λ r (q<r , Lr) →
+              is-downwards-rounded-lower-type-ℚ L r q
+                ( leq-le-ℚ q<r)
+                ( Lr))))
 ```
 
 ## See also

--- a/src/real-numbers/upper-dedekind-real-numbers.lagda.md
+++ b/src/real-numbers/upper-dedekind-real-numbers.lagda.md
@@ -15,6 +15,7 @@ open import elementary-number-theory.difference-rational-numbers
 open import elementary-number-theory.inequality-rational-numbers
 open import elementary-number-theory.positive-rational-numbers
 open import elementary-number-theory.rational-numbers
+open import elementary-number-theory.rounded-upper-subsets-rational-numbers
 open import elementary-number-theory.strict-inequality-rational-numbers
 
 open import foundation.conjunction
@@ -25,6 +26,7 @@ open import foundation.dependent-products-truncated-types
 open import foundation.existential-quantification
 open import foundation.function-types
 open import foundation.identity-types
+open import foundation.inhabited-subtypes
 open import foundation.logical-equivalences
 open import foundation.propositions
 open import foundation.sets
@@ -195,6 +197,30 @@ module _
   eq-sim-cut-upper-ℝ : sim-subtype (cut-upper-ℝ x) (cut-upper-ℝ y) → x ＝ y
   eq-sim-cut-upper-ℝ =
     eq-eq-cut-upper-ℝ ∘ eq-sim-subtype (cut-upper-ℝ x) (cut-upper-ℝ y)
+```
+
+### Any inhabited rounded upper subset of rational numbers defines an upper real
+
+```agda
+module _
+  {l : Level}
+  (U : rounded-upper-type-ℚ l)
+  (H : is-inhabited-subtype (subtype-rounded-upper-type-ℚ U))
+  where
+
+  upper-real-is-inhabited-rounded-upper-type-ℚ : upper-ℝ l
+  pr1 upper-real-is-inhabited-rounded-upper-type-ℚ =
+    subtype-rounded-upper-type-ℚ U
+  pr2 upper-real-is-inhabited-rounded-upper-type-ℚ =
+    ( H ,
+      λ q →
+        ( is-rounded-upper-type-rounded-upper-type-ℚ U q ,
+          elim-exists
+            ( subtype-rounded-upper-type-ℚ U q)
+            ( λ r (r<q , Ur) →
+              is-upwards-rounded-upper-type-ℚ U r q
+                ( leq-le-ℚ r<q)
+                ( Ur))))
 ```
 
 ## See also


### PR DESCRIPTION
This PR introduces the following modules: 
- `order-theory.upper-types-preorders`: **upper type in a preorder**, duals of `order-theory.lower-types-preorders.lagda.md`, i.e., _lower types_ in the _opposite_ preorder;
- `elementary-number-theory.rounded-lower-subsets-rational-numbers`: _lower subsets_ `L` of rational numbers such that 
```text
  ∀ (q : ℚ),  L q ⇒ ∃ (r : ℚ) | (q < r) ∧ L r;
``` 
- `elementary-number-theory.rounded-upper-subsets-rational-numbers`: _upper subsets_ `U` of rational numbers such that 
```text
  ∀ (r : ℚ),  U r ⇒ ∃ (q : ℚ) | (q < r) ∧ U q;
```

Any lower/upper subset of `ℚ` can be **rounded**. Moreover, any lower/upper set  with inhabited rounding defines a lower/upper Dedekind real number.

