### PR TITLE
Large substructures of large group-theoretic structures

### DIFF
--- a/src/foundation.lagda.md
+++ b/src/foundation.lagda.md
@@ -285,6 +285,9 @@ open import foundation.images-subtypes public
 open import foundation.implicit-function-types public
 open import foundation.impredicative-encodings public
 open import foundation.impredicative-universes public
+open import foundation.induced-large-binary-relations-large-subtypes public
+open import foundation.induced-large-equivalence-relations-large-subtypes public
+open import foundation.induced-large-similarity-relations-large-subtypes public
 open import foundation.induction-principle-propositional-truncation public
 open import foundation.inequality-booleans public
 open import foundation.inequality-truncation-levels public
@@ -321,6 +324,7 @@ open import foundation.large-identity-types public
 open import foundation.large-locale-of-propositions public
 open import foundation.large-locale-of-subtypes public
 open import foundation.large-similarity-relations public
+open import foundation.large-subtypes public
 open import foundation.law-of-excluded-middle public
 open import foundation.lawveres-fixed-point-theorem public
 open import foundation.lesser-limited-principle-of-omniscience public
@@ -478,6 +482,7 @@ open import foundation.structure public
 open import foundation.structure-identity-principle public
 open import foundation.structured-equality-duality public
 open import foundation.structured-type-duality public
+open import foundation.subsets-cumulative-large-sets public
 open import foundation.subsingleton-induction public
 open import foundation.subterminal-types public
 open import foundation.subtype-duality public

--- a/src/foundation/induced-large-binary-relations-large-subtypes.lagda.md
+++ b/src/foundation/induced-large-binary-relations-large-subtypes.lagda.md
@@ -1,0 +1,98 @@
+# Induced large binary relations on large subtypes
+
+```agda
+module foundation.induced-large-binary-relations-large-subtypes where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.large-binary-relations
+open import foundation.large-subtypes
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+Given a [large subtype](foundation.large-subtypes.md) `S` of a
+universe-polymorphic type `X : (l : Level) → UU (α l)`, any
+[large binary relation](foundation.large-binary-relations.md) `R` on `X` induces
+a large binary relation on `S`.
+
+## Definition
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype γ X)
+  where
+
+  large-relation-large-subtype :
+    Large-Relation β X → Large-Relation β (type-large-subtype S)
+  large-relation-large-subtype R (x , _) (y , _) = R x y
+
+  large-relation-prop-large-subtype :
+    Large-Relation-Prop β X → Large-Relation-Prop β (type-large-subtype S)
+  large-relation-prop-large-subtype R (x , _) (y , _) = R x y
+```
+
+## Properties
+
+### The induced relation of a large subtype preserves reflexivity
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype γ X)
+  (R : Large-Relation β X)
+  where
+
+  refl-large-relation-large-subtype :
+    is-reflexive-Large-Relation X R →
+    is-reflexive-Large-Relation
+      ( type-large-subtype S)
+      ( large-relation-large-subtype S R)
+  refl-large-relation-large-subtype refl-R (x , _) = refl-R x
+```
+
+### The induced relation of a large subtype preserves symmetry
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype γ X)
+  (R : Large-Relation β X)
+  where
+
+  is-symmetric-large-relation-large-subtype :
+    is-symmetric-Large-Relation X R →
+    is-symmetric-Large-Relation
+      ( type-large-subtype S)
+      ( large-relation-large-subtype S R)
+  is-symmetric-large-relation-large-subtype sym-R (x , _) (y , _) = sym-R x y
+```
+
+### The induced relation of a large subtype preserves transitivity
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype γ X)
+  (R : Large-Relation β X)
+  where
+
+  is-transitive-large-relation-large-subtype :
+    is-transitive-Large-Relation X R →
+    is-transitive-Large-Relation
+      ( type-large-subtype S)
+      ( large-relation-large-subtype S R)
+  is-transitive-large-relation-large-subtype trans-R (x , _) (y , _) (z , _) =
+    trans-R x y z
+```

--- a/src/foundation/induced-large-equivalence-relations-large-subtypes.lagda.md
+++ b/src/foundation/induced-large-equivalence-relations-large-subtypes.lagda.md
@@ -1,0 +1,88 @@
+# Induced large equivalence relations on large subtypes
+
+```agda
+module foundation.induced-large-equivalence-relations-large-subtypes where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.induced-large-binary-relations-large-subtypes
+open import foundation.large-binary-relations
+open import foundation.large-equivalence-relations
+open import foundation.large-subtypes
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+Given a [large subtype](foundation.large-subtypes.md) `S` of a
+universe-polymorphic type `X : (l : Level) → UU (α l)`, any
+[large equivalence relation](foundation.large-equivalence-relations.md) `R` on
+`X` induces a large equivalence relation on `S`.
+
+## Definition
+
+```agda
+module _
+  {α β : Level → Level} {γ : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype β X)
+  (R : Large-Equivalence-Relation γ X)
+  where
+
+  sim-prop-large-subtype-Large-Equivalence-Relation :
+    Large-Relation-Prop γ (type-large-subtype S)
+  sim-prop-large-subtype-Large-Equivalence-Relation =
+    large-relation-prop-large-subtype
+      ( S)
+      ( sim-prop-Large-Equivalence-Relation R)
+
+  sim-large-subtype-Large-Equivalence-Relation :
+    Large-Relation γ (type-large-subtype S)
+  sim-large-subtype-Large-Equivalence-Relation =
+    large-relation-Large-Relation-Prop
+      ( type-large-subtype S)
+      ( sim-prop-large-subtype-Large-Equivalence-Relation)
+
+  refl-sim-large-subtype-Large-Equivalence-Relation :
+    is-reflexive-Large-Relation
+      ( type-large-subtype S)
+      ( sim-large-subtype-Large-Equivalence-Relation)
+  refl-sim-large-subtype-Large-Equivalence-Relation =
+    refl-large-relation-large-subtype
+      ( S)
+      ( sim-Large-Equivalence-Relation R)
+      ( refl-sim-Large-Equivalence-Relation R)
+
+  symmetric-sim-large-subtype-Large-Equivalence-Relation :
+    is-symmetric-Large-Relation
+      ( type-large-subtype S)
+      ( sim-large-subtype-Large-Equivalence-Relation)
+  symmetric-sim-large-subtype-Large-Equivalence-Relation =
+    is-symmetric-large-relation-large-subtype
+      ( S)
+      ( sim-Large-Equivalence-Relation R)
+      ( symmetric-sim-Large-Equivalence-Relation R)
+
+  transitive-sim-large-subtype-Large-Equivalence-Relation :
+    is-transitive-Large-Relation
+      ( type-large-subtype S)
+      ( sim-large-subtype-Large-Equivalence-Relation)
+  transitive-sim-large-subtype-Large-Equivalence-Relation =
+    is-transitive-large-relation-large-subtype
+      ( S)
+      ( sim-Large-Equivalence-Relation R)
+      ( transitive-sim-Large-Equivalence-Relation R)
+
+  large-equivalence-relation-large-subtype-Large-Equivalence-Relation :
+    Large-Equivalence-Relation γ (type-large-subtype S)
+  large-equivalence-relation-large-subtype-Large-Equivalence-Relation =
+    make-Large-Equivalence-Relation
+      ( sim-prop-large-subtype-Large-Equivalence-Relation)
+      ( refl-sim-large-subtype-Large-Equivalence-Relation)
+      ( symmetric-sim-large-subtype-Large-Equivalence-Relation)
+      ( transitive-sim-large-subtype-Large-Equivalence-Relation)
+```

--- a/src/foundation/induced-large-similarity-relations-large-subtypes.lagda.md
+++ b/src/foundation/induced-large-similarity-relations-large-subtypes.lagda.md
@@ -1,0 +1,64 @@
+# Induced large similarity relations on large subtypes
+
+```agda
+module foundation.induced-large-similarity-relations-large-subtypes where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.induced-large-equivalence-relations-large-subtypes
+open import foundation.large-binary-relations
+open import foundation.large-equivalence-relations
+open import foundation.large-similarity-relations
+open import foundation.large-subtypes
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+Given a [large subtype](foundation.large-subtypes.md) `S` of a
+universe-polymorphic type `X : (l : Level) → UU (α l)`, any
+[large similarity relation](foundation.large-similarity-relations.md) `R` on `X`
+induces a large similarity relation on `S`.
+
+## Definition
+
+```agda
+module _
+  {α β : Level → Level} {γ : Level → Level → Level}
+  {X : (l : Level) → UU (α l)}
+  (S : large-subtype β X)
+  (R : Large-Similarity-Relation γ X)
+  where
+
+  large-equivalence-relation-large-subtype-Large-Similarity-Relation :
+    Large-Equivalence-Relation γ (type-large-subtype S)
+  large-equivalence-relation-large-subtype-Large-Similarity-Relation =
+    large-equivalence-relation-large-subtype-Large-Equivalence-Relation
+      ( S)
+      ( large-equivalence-relation-Large-Similarity-Relation R)
+
+  sim-large-subtype-Large-Similarity-Relation :
+    Large-Relation γ (type-large-subtype S)
+  sim-large-subtype-Large-Similarity-Relation =
+    sim-Large-Equivalence-Relation
+      ( large-equivalence-relation-large-subtype-Large-Similarity-Relation)
+
+  eq-sim-large-subtype-Large-Similarity-Relation :
+    {l : Level} (x y : type-large-subtype S l) →
+    sim-large-subtype-Large-Similarity-Relation x y → x ＝ y
+  eq-sim-large-subtype-Large-Similarity-Relation (x , _) (y , _) x~y =
+    eq-type-large-subtype S (eq-sim-Large-Similarity-Relation R x y x~y)
+
+  large-similarity-relation-large-subtype-Large-Similarity-Relation :
+    Large-Similarity-Relation γ (type-large-subtype S)
+  large-similarity-relation-large-subtype-Large-Similarity-Relation =
+    make-Large-Similarity-Relation
+      ( large-equivalence-relation-large-subtype-Large-Similarity-Relation)
+      ( eq-sim-large-subtype-Large-Similarity-Relation)
+```

--- a/src/foundation/large-similarity-relations.lagda.md
+++ b/src/foundation/large-similarity-relations.lagda.md
@@ -62,7 +62,7 @@ record
 
   field
     eq-sim-Large-Similarity-Relation :
-      {l : Level} → (x y : X l) → sim-Large-Similarity-Relation x y → x ＝ y
+      {l : Level} (x y : X l) → sim-Large-Similarity-Relation x y → x ＝ y
 
   sim-eq-Large-Similarity-Relation :
     {l : Level} {x y : X l} → x ＝ y → sim-Large-Similarity-Relation x y

--- a/src/foundation/large-subtypes.lagda.md
+++ b/src/foundation/large-subtypes.lagda.md
@@ -1,0 +1,62 @@
+# Large subtypes
+
+```agda
+module foundation.large-subtypes where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.subtypes
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+A {{#concept "large subtype"}} of a universe polymorphic type
+`X : (l : Level) → UU (α l)` is a [subtype](foundation.subtypes.md) of `X l` at
+each universe level `l`.
+
+## Definition
+
+```agda
+large-subtype :
+  {α : Level → Level} → (Level → Level) → ((l : Level) → UU (α l)) → UUω
+large-subtype β X = (l : Level) → subtype (β l) (X l)
+
+type-large-subtype :
+  {α β : Level → Level} {X : (l : Level) → UU (α l)} →
+  large-subtype β X → (l : Level) → UU (α l ⊔ β l)
+type-large-subtype S l = type-subtype (S l)
+
+is-in-large-subtype :
+  {α β : Level → Level} {X : (l : Level) → UU (α l)} {l : Level} →
+  large-subtype β X → X l → UU (β l)
+is-in-large-subtype {l = l} S = is-in-subtype (S l)
+
+prop-is-in-large-subtype :
+  {α β : Level → Level} {X : (l : Level) → UU (α l)} {l : Level} →
+  large-subtype β X → X l → Prop (β l)
+prop-is-in-large-subtype {l = l} S = S l
+
+inclusion-large-subtype :
+  {α β : Level → Level} {X : (l : Level) → UU (α l)} (S : large-subtype β X) →
+  {l : Level} → type-large-subtype S l → X l
+inclusion-large-subtype S = pr1
+```
+
+## Properties
+
+### Equality on large subtypes
+
+```agda
+eq-type-large-subtype :
+  {α β : Level → Level} {X : (l : Level) → UU (α l)} (S : large-subtype β X) →
+  {l : Level} {x y : type-large-subtype S l} → pr1 x ＝ pr1 y → x ＝ y
+eq-type-large-subtype S {l} = eq-type-subtype (S l)
+```

--- a/src/foundation/subsets-cumulative-large-sets.lagda.md
+++ b/src/foundation/subsets-cumulative-large-sets.lagda.md
@@ -1,0 +1,217 @@
+# Subsets of cumulative large sets
+
+```agda
+module foundation.subsets-cumulative-large-sets where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cumulative-large-sets
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.induced-large-similarity-relations-large-subtypes
+open import foundation.large-subtypes
+open import foundation.propositions
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a cumulative large set" Agda=Subset-Cumulative-Large-Set}}
+of a [cumulative large set](foundation.cumulative-large-sets.md) `X` is a
+[large subtype](foundation.large-subtypes.md) `S` of `X` such that if `x` is
+similar to `y` and `x ∈ S`, then `y ∈ S`.
+
+## Definition
+
+```agda
+record
+  Subset-Cumulative-Large-Set
+    { α : Level → Level}
+    { β : Level → Level → Level}
+    ( γ : Level → Level)
+    ( S : Cumulative-Large-Set α β) :
+    UUω
+  where
+
+  constructor
+    make-Subset-Cumulative-Large-Set
+
+  field
+    large-subtype-Subset-Cumulative-Large-Set :
+      large-subtype γ (type-Cumulative-Large-Set S)
+
+  type-Subset-Cumulative-Large-Set :
+    (l : Level) → UU (α l ⊔ γ l)
+  type-Subset-Cumulative-Large-Set =
+    type-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  is-in-Subset-Cumulative-Large-Set :
+    {l : Level} → type-Cumulative-Large-Set S l → UU (γ l)
+  is-in-Subset-Cumulative-Large-Set =
+    is-in-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  prop-is-in-Subset-Cumulative-Large-Set :
+    {l : Level} → type-Cumulative-Large-Set S l → Prop (γ l)
+  prop-is-in-Subset-Cumulative-Large-Set =
+    prop-is-in-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  inclusion-Subset-Cumulative-Large-Set :
+    {l : Level} →
+    type-Subset-Cumulative-Large-Set l → type-Cumulative-Large-Set S l
+  inclusion-Subset-Cumulative-Large-Set =
+    inclusion-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  field
+    sim-is-in-Subset-Cumulative-Large-Set :
+      {l1 l2 : Level}
+      (x : type-Cumulative-Large-Set S l1)
+      (y : type-Cumulative-Large-Set S l2) →
+      sim-Cumulative-Large-Set S x y →
+      is-in-Subset-Cumulative-Large-Set x →
+      is-in-Subset-Cumulative-Large-Set y
+
+  sim-is-in-Subset-Cumulative-Large-Set' :
+    {l1 l2 : Level}
+    (x : type-Cumulative-Large-Set S l1)
+    (y : type-Cumulative-Large-Set S l2) →
+    sim-Cumulative-Large-Set S x y →
+    is-in-Subset-Cumulative-Large-Set y →
+    is-in-Subset-Cumulative-Large-Set x
+  sim-is-in-Subset-Cumulative-Large-Set' x y x~y y∈S =
+    sim-is-in-Subset-Cumulative-Large-Set
+      ( y)
+      ( x)
+      ( symmetric-sim-Cumulative-Large-Set S x y x~y)
+      ( y∈S)
+
+open Subset-Cumulative-Large-Set public
+```
+
+## Properties
+
+### Identity of elements in a subset of a cumulative large set
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  abstract
+    eq-type-Subset-Cumulative-Large-Set :
+      {l : Level} {x y : type-Subset-Cumulative-Large-Set S l} →
+      ( inclusion-Subset-Cumulative-Large-Set S x ＝
+        inclusion-Subset-Cumulative-Large-Set S y) →
+      x ＝ y
+    eq-type-Subset-Cumulative-Large-Set =
+      eq-type-large-subtype (large-subtype-Subset-Cumulative-Large-Set S)
+```
+
+### `x` is in a subset if and only if `raise l x` is
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  abstract
+    is-closed-under-raise-Subset-Cumulative-Large-Set :
+      {l1 : Level} (l2 : Level) (x : type-Cumulative-Large-Set X l1) →
+      is-in-Subset-Cumulative-Large-Set S x →
+      is-in-Subset-Cumulative-Large-Set S (raise-Cumulative-Large-Set X l2 x)
+    is-closed-under-raise-Subset-Cumulative-Large-Set l2 x =
+      sim-is-in-Subset-Cumulative-Large-Set
+        ( S)
+        ( x)
+        ( raise-Cumulative-Large-Set X l2 x)
+        ( sim-raise-Cumulative-Large-Set X l2 x)
+
+    is-closed-under-raise-Subset-Cumulative-Large-Set' :
+      {l1 : Level} (l2 : Level) (x : type-Cumulative-Large-Set X l1) →
+      is-in-Subset-Cumulative-Large-Set S (raise-Cumulative-Large-Set X l2 x) →
+      is-in-Subset-Cumulative-Large-Set S x
+    is-closed-under-raise-Subset-Cumulative-Large-Set' l2 x =
+      sim-is-in-Subset-Cumulative-Large-Set'
+        ( S)
+        ( x)
+        ( raise-Cumulative-Large-Set X l2 x)
+        ( sim-raise-Cumulative-Large-Set X l2 x)
+
+  raise-type-Subset-Cumulative-Large-Set :
+    {l1 : Level} (l2 : Level) →
+    type-Subset-Cumulative-Large-Set S l1 →
+    type-Subset-Cumulative-Large-Set S (l1 ⊔ l2)
+  raise-type-Subset-Cumulative-Large-Set l2 (x , x∈S) =
+    ( raise-Cumulative-Large-Set X l2 x ,
+      is-closed-under-raise-Subset-Cumulative-Large-Set l2 x x∈S)
+```
+
+### A subset induces a cumulative large set
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  cumulative-large-set-Subset-Cumulative-Large-Set :
+    Cumulative-Large-Set (λ l → α l ⊔ γ l) β
+  cumulative-large-set-Subset-Cumulative-Large-Set =
+    make-Cumulative-Large-Set
+      ( type-large-subtype (large-subtype-Subset-Cumulative-Large-Set S))
+      ( large-similarity-relation-large-subtype-Large-Similarity-Relation
+        ( large-subtype-Subset-Cumulative-Large-Set S)
+        ( large-similarity-relation-Cumulative-Large-Set X))
+      ( raise-type-Subset-Cumulative-Large-Set S)
+      ( λ l (x , _) → sim-raise-Cumulative-Large-Set X l x)
+```
+
+### The inclusion map on a cumulative large set preserves similarity
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  preserves-sim-inclusion-Subset-Cumulative-Large-Set :
+    preserves-sim-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+      ( inclusion-Subset-Cumulative-Large-Set S)
+  preserves-sim-inclusion-Subset-Cumulative-Large-Set _ _ x~y = x~y
+
+  sim-preserving-map-inclusion-Subset-Cumulative-Large-Set :
+    sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+  sim-preserving-map-inclusion-Subset-Cumulative-Large-Set =
+    make-sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+      ( inclusion-Subset-Cumulative-Large-Set S)
+      ( preserves-sim-inclusion-Subset-Cumulative-Large-Set)
+```

--- a/src/foundation/subsets-cumulative-large-sets.lagda.md
+++ b/src/foundation/subsets-cumulative-large-sets.lagda.md
@@ -1,0 +1,225 @@
+# Subsets of cumulative large sets
+
+```agda
+module foundation.subsets-cumulative-large-sets where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cumulative-large-sets
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.induced-large-similarity-relations-large-subtypes
+open import foundation.large-similarity-relations
+open import foundation.large-subtypes
+open import foundation.propositions
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.universe-levels
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a cumulative large set" Agda=Subset-Cumulative-Large-Set}}
+of a [cumulative large set](foundation.cumulative-large-sets.md) `X` is a
+[large subtype](foundation.large-subtypes.md) `S` of `X` such that if `x` is
+similar to `y` and `x ∈ S`, then `y ∈ S`.
+
+## Definition
+
+```agda
+record
+  Subset-Cumulative-Large-Set
+    { α : Level → Level}
+    { β : Level → Level → Level}
+    ( γ : Level → Level)
+    ( S : Cumulative-Large-Set α β) :
+    UUω
+  where
+
+  constructor
+    make-Subset-Cumulative-Large-Set
+
+  field
+    large-subtype-Subset-Cumulative-Large-Set :
+      large-subtype γ (type-Cumulative-Large-Set S)
+
+  type-Subset-Cumulative-Large-Set :
+    (l : Level) → UU (α l ⊔ γ l)
+  type-Subset-Cumulative-Large-Set =
+    type-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  is-in-Subset-Cumulative-Large-Set :
+    {l : Level} → type-Cumulative-Large-Set S l → UU (γ l)
+  is-in-Subset-Cumulative-Large-Set =
+    is-in-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  prop-is-in-Subset-Cumulative-Large-Set :
+    {l : Level} → type-Cumulative-Large-Set S l → Prop (γ l)
+  prop-is-in-Subset-Cumulative-Large-Set =
+    prop-is-in-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  inclusion-Subset-Cumulative-Large-Set :
+    {l : Level} →
+    type-Subset-Cumulative-Large-Set l → type-Cumulative-Large-Set S l
+  inclusion-Subset-Cumulative-Large-Set =
+    inclusion-large-subtype large-subtype-Subset-Cumulative-Large-Set
+
+  field
+    sim-is-in-Subset-Cumulative-Large-Set :
+      {l1 l2 : Level}
+      (x : type-Cumulative-Large-Set S l1)
+      (y : type-Cumulative-Large-Set S l2) →
+      sim-Cumulative-Large-Set S x y →
+      is-in-Subset-Cumulative-Large-Set x →
+      is-in-Subset-Cumulative-Large-Set y
+
+  sim-is-in-Subset-Cumulative-Large-Set' :
+    {l1 l2 : Level}
+    (x : type-Cumulative-Large-Set S l1)
+    (y : type-Cumulative-Large-Set S l2) →
+    sim-Cumulative-Large-Set S x y →
+    is-in-Subset-Cumulative-Large-Set y →
+    is-in-Subset-Cumulative-Large-Set x
+  sim-is-in-Subset-Cumulative-Large-Set' x y x~y y∈S =
+    sim-is-in-Subset-Cumulative-Large-Set
+      ( y)
+      ( x)
+      ( symmetric-sim-Cumulative-Large-Set S x y x~y)
+      ( y∈S)
+
+open Subset-Cumulative-Large-Set public
+```
+
+## Properties
+
+### Identity of elements in a subset of a cumulative large set
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  abstract
+    eq-type-Subset-Cumulative-Large-Set :
+      {l : Level} {x y : type-Subset-Cumulative-Large-Set S l} →
+      ( inclusion-Subset-Cumulative-Large-Set S x ＝
+        inclusion-Subset-Cumulative-Large-Set S y) →
+      x ＝ y
+    eq-type-Subset-Cumulative-Large-Set =
+      eq-type-large-subtype (large-subtype-Subset-Cumulative-Large-Set S)
+```
+
+### `x` is in a subset if and only if `raise l x` is
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  abstract
+    is-closed-under-raise-Subset-Cumulative-Large-Set :
+      {l1 : Level} (l2 : Level) (x : type-Cumulative-Large-Set X l1) →
+      is-in-Subset-Cumulative-Large-Set S x →
+      is-in-Subset-Cumulative-Large-Set S (raise-Cumulative-Large-Set X l2 x)
+    is-closed-under-raise-Subset-Cumulative-Large-Set l2 x =
+      sim-is-in-Subset-Cumulative-Large-Set
+        ( S)
+        ( x)
+        ( raise-Cumulative-Large-Set X l2 x)
+        ( sim-raise-Cumulative-Large-Set X l2 x)
+
+    is-closed-under-raise-Subset-Cumulative-Large-Set' :
+      {l1 : Level} (l2 : Level) (x : type-Cumulative-Large-Set X l1) →
+      is-in-Subset-Cumulative-Large-Set S (raise-Cumulative-Large-Set X l2 x) →
+      is-in-Subset-Cumulative-Large-Set S x
+    is-closed-under-raise-Subset-Cumulative-Large-Set' l2 x =
+      sim-is-in-Subset-Cumulative-Large-Set'
+        ( S)
+        ( x)
+        ( raise-Cumulative-Large-Set X l2 x)
+        ( sim-raise-Cumulative-Large-Set X l2 x)
+
+  raise-type-Subset-Cumulative-Large-Set :
+    {l1 : Level} (l2 : Level) →
+    type-Subset-Cumulative-Large-Set S l1 →
+    type-Subset-Cumulative-Large-Set S (l1 ⊔ l2)
+  raise-type-Subset-Cumulative-Large-Set l2 (x , x∈S) =
+    ( raise-Cumulative-Large-Set X l2 x ,
+      is-closed-under-raise-Subset-Cumulative-Large-Set l2 x x∈S)
+```
+
+### A subset induces a cumulative large set
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  large-similarity-relation-Subset-Cumulative-Large-Set :
+    Large-Similarity-Relation
+      ( β)
+      ( type-Subset-Cumulative-Large-Set S)
+  large-similarity-relation-Subset-Cumulative-Large-Set =
+    large-similarity-relation-large-subtype-Large-Similarity-Relation
+      ( large-subtype-Subset-Cumulative-Large-Set S)
+      ( large-similarity-relation-Cumulative-Large-Set X)
+
+  cumulative-large-set-Subset-Cumulative-Large-Set :
+    Cumulative-Large-Set (λ l → α l ⊔ γ l) β
+  cumulative-large-set-Subset-Cumulative-Large-Set =
+    make-Cumulative-Large-Set
+      ( type-Subset-Cumulative-Large-Set S)
+      ( large-similarity-relation-Subset-Cumulative-Large-Set)
+      ( raise-type-Subset-Cumulative-Large-Set S)
+      ( λ l (x , _) → sim-raise-Cumulative-Large-Set X l x)
+```
+
+### The inclusion map on a cumulative large set preserves similarity
+
+```agda
+module _
+  {α : Level → Level}
+  {β : Level → Level → Level}
+  {γ : Level → Level}
+  {X : Cumulative-Large-Set α β}
+  (S : Subset-Cumulative-Large-Set γ X)
+  where
+
+  preserves-sim-inclusion-Subset-Cumulative-Large-Set :
+    preserves-sim-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+      ( inclusion-Subset-Cumulative-Large-Set S)
+  preserves-sim-inclusion-Subset-Cumulative-Large-Set _ _ x~y = x~y
+
+  sim-preserving-map-inclusion-Subset-Cumulative-Large-Set :
+    sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+  sim-preserving-map-inclusion-Subset-Cumulative-Large-Set =
+    make-sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Subset-Cumulative-Large-Set S)
+      ( X)
+      ( inclusion-Subset-Cumulative-Large-Set S)
+      ( preserves-sim-inclusion-Subset-Cumulative-Large-Set)
+```

--- a/src/group-theory.lagda.md
+++ b/src/group-theory.lagda.md
@@ -211,6 +211,11 @@ open import group-theory.subsemigroups public
 open import group-theory.subsets-abelian-groups public
 open import group-theory.subsets-commutative-monoids public
 open import group-theory.subsets-groups public
+open import group-theory.subsets-large-abelian-groups public
+open import group-theory.subsets-large-commutative-monoids public
+open import group-theory.subsets-large-groups public
+open import group-theory.subsets-large-monoids public
+open import group-theory.subsets-large-semigroups public
 open import group-theory.subsets-monoids public
 open import group-theory.subsets-semigroups public
 open import group-theory.substitution-functor-concrete-group-actions public

--- a/src/group-theory.lagda.md
+++ b/src/group-theory.lagda.md
@@ -98,6 +98,11 @@ open import group-theory.homomorphisms-generated-subgroups public
 open import group-theory.homomorphisms-group-actions public
 open import group-theory.homomorphisms-groups public
 open import group-theory.homomorphisms-groups-equipped-with-normal-subgroups public
+open import group-theory.homomorphisms-large-abelian-groups public
+open import group-theory.homomorphisms-large-commutative-monoids public
+open import group-theory.homomorphisms-large-groups public
+open import group-theory.homomorphisms-large-monoids public
+open import group-theory.homomorphisms-large-semigroups public
 open import group-theory.homomorphisms-monoids public
 open import group-theory.homomorphisms-semigroups public
 open import group-theory.homotopy-automorphism-groups public
@@ -123,7 +128,9 @@ open import group-theory.kernels-homomorphisms-abelian-groups public
 open import group-theory.kernels-homomorphisms-concrete-groups public
 open import group-theory.kernels-homomorphisms-groups public
 open import group-theory.large-abelian-groups public
+open import group-theory.large-abelian-subgroups public
 open import group-theory.large-commutative-monoids public
+open import group-theory.large-commutative-submonoids public
 open import group-theory.large-function-abelian-groups public
 open import group-theory.large-function-commutative-monoids public
 open import group-theory.large-function-groups public
@@ -132,6 +139,9 @@ open import group-theory.large-function-semigroups public
 open import group-theory.large-groups public
 open import group-theory.large-monoids public
 open import group-theory.large-semigroups public
+open import group-theory.large-subgroups public
+open import group-theory.large-submonoids public
+open import group-theory.large-subsemigroups public
 open import group-theory.loop-groups-sets public
 open import group-theory.mere-equivalences-concrete-group-actions public
 open import group-theory.mere-equivalences-group-actions public
@@ -211,6 +221,11 @@ open import group-theory.subsemigroups public
 open import group-theory.subsets-abelian-groups public
 open import group-theory.subsets-commutative-monoids public
 open import group-theory.subsets-groups public
+open import group-theory.subsets-large-abelian-groups public
+open import group-theory.subsets-large-commutative-monoids public
+open import group-theory.subsets-large-groups public
+open import group-theory.subsets-large-monoids public
+open import group-theory.subsets-large-semigroups public
 open import group-theory.subsets-monoids public
 open import group-theory.subsets-semigroups public
 open import group-theory.substitution-functor-concrete-group-actions public

--- a/src/group-theory.lagda.md
+++ b/src/group-theory.lagda.md
@@ -98,6 +98,11 @@ open import group-theory.homomorphisms-generated-subgroups public
 open import group-theory.homomorphisms-group-actions public
 open import group-theory.homomorphisms-groups public
 open import group-theory.homomorphisms-groups-equipped-with-normal-subgroups public
+open import group-theory.homomorphisms-large-abelian-groups public
+open import group-theory.homomorphisms-large-commutative-monoids public
+open import group-theory.homomorphisms-large-groups public
+open import group-theory.homomorphisms-large-monoids public
+open import group-theory.homomorphisms-large-semigroups public
 open import group-theory.homomorphisms-monoids public
 open import group-theory.homomorphisms-semigroups public
 open import group-theory.homotopy-automorphism-groups public

--- a/src/group-theory/homomorphisms-large-abelian-groups.lagda.md
+++ b/src/group-theory/homomorphisms-large-abelian-groups.lagda.md
@@ -1,0 +1,72 @@
+# Homomorphisms of large abelian groups
+
+```agda
+module group-theory.homomorphisms-large-abelian-groups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-abelian-groups
+open import group-theory.homomorphisms-large-groups
+open import group-theory.large-abelian-groups
+open import group-theory.large-groups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "homomorphism" Disambiguation="of large abelian groups" Agda=hom-Large-Ab}}
+from a [large abelian group](group-theory.large-abelian-groups.md) `G` to a
+large abelian group `H` is a
+[similarity-preserving map](foundation.similarity-preserving-maps-cumulative-large-sets.md)
+from `G` to `H` that preserves addition.
+
+## Definition
+
+We create a single-field record to ensure that the source and target large
+groups can be determined implicitly from the homomorphism.
+
+```agda
+record
+  hom-Large-Ab
+    {α β : Level → Level}
+    {γ δ : Level → Level → Level}
+    (G : Large-Ab α γ)
+    (H : Large-Ab β δ) :
+    UUω
+  where
+
+  constructor
+    make-hom-Large-Ab
+
+  field
+    hom-large-group-hom-Large-Ab :
+      hom-Large-Group
+        ( large-group-Large-Ab G)
+        ( large-group-Large-Ab H)
+
+open hom-Large-Ab public
+```
+
+## Properties
+
+### Small abelian group homomorphisms from large abelian group homomorphisms
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {G : Large-Ab α γ}
+  {H : Large-Ab β δ}
+  (f : hom-Large-Ab G H)
+  where
+
+  hom-ab-hom-Large-Ab : (l : Level) → hom-Ab (ab-Large-Ab G l) (ab-Large-Ab H l)
+  hom-ab-hom-Large-Ab =
+    hom-group-hom-Large-Group (hom-large-group-hom-Large-Ab f)
+```

--- a/src/group-theory/homomorphisms-large-commutative-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-large-commutative-monoids.lagda.md
@@ -1,0 +1,77 @@
+# Homomorphisms of large commutative monoids
+
+```agda
+module group-theory.homomorphisms-large-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-commutative-monoids
+open import group-theory.homomorphisms-large-monoids
+open import group-theory.large-commutative-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "homomorphism" Disambiguation="of large monoids" Agda=hom-Large-Monoid}}
+from a [large commutative monoid](group-theory.large-commutative-monoids.md) `M`
+to a large monoid `N` is a
+[homomorphism](group-theory.homomorphisms-large-semigroups.md) of their
+underlying [large semigroups](group-theory.large-semigroups.md) that preserves
+the unit.
+
+## Definition
+
+We create a single-field record to ensure that the source and target large
+commutative monoids can be determined implicitly from the homomorphism.
+
+```agda
+record
+  hom-Large-Commutative-Monoid
+    {α β : Level → Level}
+    {γ δ : Level → Level → Level}
+    (M : Large-Commutative-Monoid α γ)
+    (N : Large-Commutative-Monoid β δ) :
+    UUω
+  where
+
+  constructor
+    make-hom-Large-Commutative-Monoid
+
+  field
+    hom-large-monoid-hom-Large-Commutative-Monoid :
+      hom-Large-Monoid
+        ( large-monoid-Large-Commutative-Monoid M)
+        ( large-monoid-Large-Commutative-Monoid N)
+
+open hom-Large-Commutative-Monoid public
+```
+
+## Properties
+
+### Small commutative monoid homomorphisms from large ones
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {M : Large-Commutative-Monoid α γ}
+  {N : Large-Commutative-Monoid β δ}
+  (f : hom-Large-Commutative-Monoid M N)
+  where
+
+  hom-commutative-monoid-hom-Large-Commutative-Monoid :
+    (l : Level) →
+    hom-Commutative-Monoid
+      ( commutative-monoid-Large-Commutative-Monoid M l)
+      ( commutative-monoid-Large-Commutative-Monoid N l)
+  hom-commutative-monoid-hom-Large-Commutative-Monoid =
+    hom-monoid-hom-Large-Monoid
+      ( hom-large-monoid-hom-Large-Commutative-Monoid f)
+```

--- a/src/group-theory/homomorphisms-large-commutative-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-large-commutative-monoids.lagda.md
@@ -19,7 +19,7 @@ open import group-theory.large-commutative-monoids
 ## Idea
 
 A
-{{#concept "homomorphism" Disambiguation="of large monoids" Agda=hom-Large-Monoid}}
+{{#concept "homomorphism" Disambiguation="of large commutative monoids" Agda=hom-Large-Commutative-Monoid}}
 from a [large commutative monoid](group-theory.large-commutative-monoids.md) `M`
 to a large monoid `N` is a
 [homomorphism](group-theory.homomorphisms-large-semigroups.md) of their

--- a/src/group-theory/homomorphisms-large-groups.lagda.md
+++ b/src/group-theory/homomorphisms-large-groups.lagda.md
@@ -1,0 +1,109 @@
+# Homomorphisms of large groups
+
+```agda
+module group-theory.homomorphisms-large-groups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-groups
+open import group-theory.homomorphisms-large-semigroups
+open import group-theory.large-groups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "homomorphism" Disambiguation="of large groups" Agda=hom-Large-Group}}
+of [large groups](group-theory.large-groups.md) is a
+[homomorphism](group-theory.homomorphisms-large-semigroups.md) of their
+underlying [large semigroups](group-theory.large-semigroups.md).
+
+## Definition
+
+We create a single-field record to ensure that the source and target large
+groups can be determined implicitly from the homomorphism.
+
+```agda
+record
+  hom-Large-Group
+    {α β : Level → Level}
+    {γ δ : Level → Level → Level}
+    (G : Large-Group α γ)
+    (H : Large-Group β δ) :
+    UUω
+  where
+
+  constructor
+    make-hom-Large-Group
+
+  field
+    hom-large-semigroup-hom-Large-Group :
+      hom-Large-Semigroup
+        ( large-semigroup-Large-Group G)
+        ( large-semigroup-Large-Group H)
+
+  map-hom-Large-Group :
+    {l : Level} → type-Large-Group G l → type-Large-Group H l
+  map-hom-Large-Group =
+    map-hom-Large-Semigroup hom-large-semigroup-hom-Large-Group
+
+  preserves-mul-hom-Large-Group :
+    {l1 l2 : Level} {x : type-Large-Group G l1} {y : type-Large-Group G l2} →
+    map-hom-Large-Group (mul-Large-Group G x y) ＝
+    mul-Large-Group H (map-hom-Large-Group x) (map-hom-Large-Group y)
+  preserves-mul-hom-Large-Group =
+    preserves-mul-hom-Large-Semigroup hom-large-semigroup-hom-Large-Group
+
+open hom-Large-Group public
+```
+
+## Properties
+
+### Small group homomorphisms from large group homomorphisms
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {G : Large-Group α γ}
+  {H : Large-Group β δ}
+  (f : hom-Large-Group G H)
+  where
+
+  hom-group-hom-Large-Group :
+    (l : Level) → hom-Group (group-Large-Group G l) (group-Large-Group H l)
+  hom-group-hom-Large-Group l =
+    ( map-hom-Large-Group f ,
+      preserves-mul-hom-Large-Group f)
+```
+
+### Large group homomorphisms preserve units
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {G : Large-Group α γ}
+  {H : Large-Group β δ}
+  (f : hom-Large-Group G H)
+  where
+
+  abstract
+    preserves-raise-unit-hom-Large-Group :
+      (l : Level) →
+      map-hom-Large-Group f (raise-unit-Large-Group G l) ＝
+      raise-unit-Large-Group H l
+    preserves-raise-unit-hom-Large-Group l =
+      preserves-unit-hom-Group
+        ( group-Large-Group G l)
+        ( group-Large-Group H l)
+        ( hom-group-hom-Large-Group f l)
+```

--- a/src/group-theory/homomorphisms-large-monoids.lagda.md
+++ b/src/group-theory/homomorphisms-large-monoids.lagda.md
@@ -1,0 +1,128 @@
+# Homomorphisms of large monoids
+
+```agda
+module group-theory.homomorphisms-large-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.action-on-identifications-functions
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-semigroups
+open import group-theory.homomorphisms-monoids
+open import group-theory.large-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "homomorphism" Disambiguation="of large monoids" Agda=hom-Large-Monoid}}
+from a [large monoid](group-theory.large-monoids.md) `M` to a large monoid `N`
+is a [homomorphism](group-theory.homomorphisms-large-semigroups.md) of their
+underlying [large semigroups](group-theory.large-semigroups.md) that preserves
+the unit.
+
+## Definition
+
+```agda
+record
+  hom-Large-Monoid
+    {α β : Level → Level}
+    {γ δ : Level → Level → Level}
+    (M : Large-Monoid α γ)
+    (N : Large-Monoid β δ) :
+    UUω
+  where
+
+  constructor
+    make-hom-Large-Monoid
+
+  field
+    hom-large-semigroup-hom-Large-Monoid :
+      hom-Large-Semigroup
+        ( large-semigroup-Large-Monoid M)
+        ( large-semigroup-Large-Monoid N)
+
+  sim-preserving-map-hom-Large-Monoid :
+    sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Large-Monoid M)
+      ( cumulative-large-set-Large-Monoid N)
+  sim-preserving-map-hom-Large-Monoid =
+    sim-preserving-map-hom-Large-Semigroup
+      ( hom-large-semigroup-hom-Large-Monoid)
+
+  map-hom-Large-Monoid :
+    {l : Level} → type-Large-Monoid M l → type-Large-Monoid N l
+  map-hom-Large-Monoid =
+    map-hom-Large-Semigroup hom-large-semigroup-hom-Large-Monoid
+
+  field
+    preserves-unit-hom-Large-Monoid :
+      map-hom-Large-Monoid (unit-Large-Monoid M) ＝ unit-Large-Monoid N
+
+  preserves-mul-hom-Large-Monoid :
+    {l1 l2 : Level} {x : type-Large-Monoid M l1} {y : type-Large-Monoid M l2} →
+    map-hom-Large-Monoid (mul-Large-Monoid M x y) ＝
+    mul-Large-Monoid N (map-hom-Large-Monoid x) (map-hom-Large-Monoid y)
+  preserves-mul-hom-Large-Monoid =
+    preserves-mul-hom-Large-Semigroup hom-large-semigroup-hom-Large-Monoid
+
+open hom-Large-Monoid public
+```
+
+## Properties
+
+### Monoid homomorphisms preserve raised units
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {M : Large-Monoid α γ}
+  {N : Large-Monoid β δ}
+  (f : hom-Large-Monoid M N)
+  where abstract
+
+  preserves-raise-unit-hom-Large-Monoid :
+    (l : Level) →
+    map-hom-Large-Monoid f (raise-unit-Large-Monoid M l) ＝
+    raise-unit-Large-Monoid N l
+  preserves-raise-unit-hom-Large-Monoid l =
+    commute-map-raise-sim-preserving-map-Cumulative-Large-Set
+      ( cumulative-large-set-Large-Monoid M)
+      ( cumulative-large-set-Large-Monoid N)
+      ( sim-preserving-map-hom-Large-Monoid f)
+      ( l)
+      ( unit-Large-Monoid M) ∙
+    ( ap (raise-Large-Monoid N l) (preserves-unit-hom-Large-Monoid f))
+```
+
+### Small monoid homomorphisms from large ones
+
+```agda
+module _
+  {α β : Level → Level}
+  {γ δ : Level → Level → Level}
+  {M : Large-Monoid α γ}
+  {N : Large-Monoid β δ}
+  (f : hom-Large-Monoid M N)
+  where
+
+  hom-monoid-hom-Large-Monoid :
+    (l : Level) →
+    hom-Monoid (monoid-Large-Monoid M l) (monoid-Large-Monoid N l)
+  hom-monoid-hom-Large-Monoid l =
+    ( hom-semigroup-hom-Large-Semigroup
+        ( hom-large-semigroup-hom-Large-Monoid f)
+        ( l) ,
+      preserves-raise-unit-hom-Large-Monoid f l)
+```

--- a/src/group-theory/homomorphisms-large-semigroups.lagda.md
+++ b/src/group-theory/homomorphisms-large-semigroups.lagda.md
@@ -1,0 +1,93 @@
+# Homomorphisms of large semigroups
+
+```agda
+module group-theory.homomorphisms-large-semigroups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-semigroups
+open import group-theory.large-semigroups
+```
+
+</details>
+
+## Idea
+
+Given two [large semigroups](group-theory.large-semigroups.md) `G` and `H`, a
+{{#concept "semigroup homomorphism" Disambiguation="large semigroup" Agda=hom-Large-Semigroup}}
+from `G` to `H` is a
+[similarity-preserving map](foundation.similarity-preserving-maps-cumulative-large-sets.md)
+from `G` to `H` that preserves multiplication.
+
+## Definition
+
+```agda
+record
+  hom-Large-Semigroup
+    { α γ : Level → Level}
+    { β δ : Level → Level → Level}
+    ( G : Large-Semigroup α β)
+    ( H : Large-Semigroup γ δ) :
+    UUω
+    where
+
+  constructor
+    make-hom-Large-Semigroup
+
+  field
+    sim-preserving-map-hom-Large-Semigroup :
+      sim-preserving-map-Cumulative-Large-Set
+        ( id)
+        ( cumulative-large-set-Large-Semigroup G)
+        ( cumulative-large-set-Large-Semigroup H)
+
+  map-hom-Large-Semigroup :
+    {l : Level} → type-Large-Semigroup G l → type-Large-Semigroup H l
+  map-hom-Large-Semigroup =
+    map-sim-preserving-map-Cumulative-Large-Set
+      ( cumulative-large-set-Large-Semigroup G)
+      ( cumulative-large-set-Large-Semigroup H)
+      ( sim-preserving-map-hom-Large-Semigroup)
+
+  field
+    preserves-mul-hom-Large-Semigroup :
+      {l1 l2 : Level} →
+      {x : type-Large-Semigroup G l1} {y : type-Large-Semigroup G l2} →
+      map-hom-Large-Semigroup (mul-Large-Semigroup G x y) ＝
+      mul-Large-Semigroup H
+        ( map-hom-Large-Semigroup x)
+        ( map-hom-Large-Semigroup y)
+
+open hom-Large-Semigroup public
+```
+
+## Properties
+
+### Homomorphisms on small semigroups from homomorphisms on large semigroups
+
+```agda
+module _
+  { α γ : Level → Level}
+  { β δ : Level → Level → Level}
+  { G : Large-Semigroup α β}
+  { H : Large-Semigroup γ δ}
+  (f : hom-Large-Semigroup G H)
+  where
+
+  hom-semigroup-hom-Large-Semigroup :
+    (l : Level) →
+    hom-Semigroup
+      ( semigroup-Large-Semigroup G l)
+      ( semigroup-Large-Semigroup H l)
+  hom-semigroup-hom-Large-Semigroup l =
+    ( map-hom-Large-Semigroup f ,
+      preserves-mul-hom-Large-Semigroup f)
+```

--- a/src/group-theory/large-abelian-subgroups.lagda.md
+++ b/src/group-theory/large-abelian-subgroups.lagda.md
@@ -1,0 +1,116 @@
+# Large abelian subgroups
+
+```agda
+module group-theory.large-abelian-subgroups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-abelian-groups
+open import group-theory.large-abelian-groups
+open import group-theory.large-commutative-monoids
+open import group-theory.large-commutative-submonoids
+open import group-theory.large-groups
+open import group-theory.large-subgroups
+open import group-theory.large-submonoids
+open import group-theory.subgroups-abelian-groups
+open import group-theory.subsets-large-abelian-groups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subgroup" Disambiguation="of a large abelian group" Agda=Large-Subgroup-Ab}}
+of a [large abelian group](group-theory.large-abelian-subgroups.md) `G` is a
+[subset](group-theory.subsets-large-groups.md) `G` that contains zero and is
+closed under addition and negation.
+
+## Definition
+
+```agda
+record
+  Large-Subgroup-Ab
+    {α : Level → Level}
+    {β : Level → Level → Level}
+    (γ : Level → Level)
+    (G : Large-Ab α β) :
+    UUω
+  where
+
+  constructor
+    make-Large-Subgroup-Ab
+
+  field
+    large-subgroup-Large-Subgroup-Ab :
+      Large-Subgroup γ (large-group-Large-Ab G)
+
+  large-submonoid-Large-Subgroup-Ab :
+    Large-Submonoid γ (large-monoid-Large-Ab G)
+  large-submonoid-Large-Subgroup-Ab =
+    large-submonoid-Large-Subgroup large-subgroup-Large-Subgroup-Ab
+
+  large-commutative-submonoid-Large-Subgroup-Ab :
+    Large-Commutative-Submonoid γ (large-commutative-monoid-Large-Ab G)
+  large-commutative-submonoid-Large-Subgroup-Ab =
+    make-Large-Commutative-Submonoid large-submonoid-Large-Subgroup-Ab
+
+open Large-Subgroup-Ab public
+```
+
+## Properties
+
+### Large subgroups of abelian groups induce a large abelian group
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Ab α β}
+  (S : Large-Subgroup-Ab γ G)
+  where
+
+  large-ab-Large-Subgroup-Ab : Large-Ab (λ l → α l ⊔ γ l) β
+  large-ab-Large-Subgroup-Ab =
+    make-Large-Ab
+      ( large-group-Large-Subgroup (large-subgroup-Large-Subgroup-Ab S))
+      ( commutative-mul-Large-Commutative-Submonoid
+        ( large-commutative-submonoid-Large-Subgroup-Ab S))
+```
+
+### Small subgroups from large subgroups of abelian groups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Ab α β}
+  (S : Large-Subgroup-Ab γ G)
+  where
+
+  subgroup-ab-Large-Subgroup-Ab :
+    (l : Level) → Subgroup-Ab (γ l) (ab-Large-Ab G l)
+  subgroup-ab-Large-Subgroup-Ab =
+    subgroup-Large-Subgroup (large-subgroup-Large-Subgroup-Ab S)
+```
+
+### The inclusion homomorphism of large abelian subgroups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Ab α β}
+  (S : Large-Subgroup-Ab γ G)
+  where
+
+  inclusion-hom-Large-Subgroup-Ab :
+    hom-Large-Ab (large-ab-Large-Subgroup-Ab S) G
+  inclusion-hom-Large-Subgroup-Ab =
+    make-hom-Large-Ab
+      ( inclusion-hom-Large-Subgroup (large-subgroup-Large-Subgroup-Ab S))
+```

--- a/src/group-theory/large-commutative-submonoids.lagda.md
+++ b/src/group-theory/large-commutative-submonoids.lagda.md
@@ -1,0 +1,158 @@
+# Large commutative submonoids
+
+```agda
+module group-theory.large-commutative-submonoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-commutative-monoids
+open import group-theory.large-commutative-monoids
+open import group-theory.large-monoids
+open import group-theory.large-submonoids
+open import group-theory.submonoids-commutative-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "submonoid" Disambiguation="of a large commutative monoid" Agda=Large-Commutative-Submonoid}}
+of a [large commutative monoid](group-theory.large-commutative-monoids.md) `M`
+is a [subset](group-theory.subsets-large-commutative-monoids.md) of `M` that is
+closed under multiplication and contains the unit.
+
+## Definition
+
+We create a one-field record instead of an alias to ensure that, consistent with
+other large algebraic structures, the ambient large commutative monoid can be
+inferred from the large commutative submonoid.
+
+```agda
+record
+  Large-Commutative-Submonoid
+    {α : Level → Level}
+    {β : Level → Level → Level}
+    (γ : Level → Level)
+    (M : Large-Commutative-Monoid α β) :
+    UUω
+  where
+
+  constructor
+    make-Large-Commutative-Submonoid
+
+  field
+    large-submonoid-Large-Commutative-Submonoid :
+      Large-Submonoid γ (large-monoid-Large-Commutative-Monoid M)
+
+  type-Large-Commutative-Submonoid : (l : Level) → UU (α l ⊔ γ l)
+  type-Large-Commutative-Submonoid =
+    type-Large-Submonoid large-submonoid-Large-Commutative-Submonoid
+
+  inclusion-Large-Commutative-Submonoid :
+    {l : Level} →
+    type-Large-Commutative-Submonoid l → type-Large-Commutative-Monoid M l
+  inclusion-Large-Commutative-Submonoid = pr1
+
+  abstract
+    eq-type-Large-Commutative-Submonoid :
+      {l : Level} {x y : type-Large-Commutative-Submonoid l} →
+      ( inclusion-Large-Commutative-Submonoid x ＝
+        inclusion-Large-Commutative-Submonoid y) →
+      x ＝ y
+    eq-type-Large-Commutative-Submonoid =
+      eq-type-Large-Submonoid large-submonoid-Large-Commutative-Submonoid
+
+open Large-Commutative-Submonoid public
+```
+
+## Properties
+
+### A large commutative submonoid induces a large commutative monoid
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Commutative-Monoid α β}
+  (S : Large-Commutative-Submonoid γ M)
+  where
+
+  large-monoid-Large-Commutative-Submonoid :
+    Large-Monoid (λ l → α l ⊔ γ l) β
+  large-monoid-Large-Commutative-Submonoid =
+    large-monoid-Large-Submonoid
+      ( large-submonoid-Large-Commutative-Submonoid S)
+
+  mul-Large-Commutative-Submonoid :
+    {l1 l2 : Level} →
+    type-Large-Commutative-Submonoid S l1 →
+    type-Large-Commutative-Submonoid S l2 →
+    type-Large-Commutative-Submonoid S (l1 ⊔ l2)
+  mul-Large-Commutative-Submonoid =
+    mul-Large-Monoid large-monoid-Large-Commutative-Submonoid
+
+  abstract
+    commutative-mul-Large-Commutative-Submonoid :
+      {l1 l2 : Level}
+      (x : type-Large-Commutative-Submonoid S l1)
+      (y : type-Large-Commutative-Submonoid S l2) →
+      mul-Large-Commutative-Submonoid x y ＝
+      mul-Large-Commutative-Submonoid y x
+    commutative-mul-Large-Commutative-Submonoid (x , _) (y , _) =
+      eq-type-Large-Commutative-Submonoid
+        ( S)
+        ( commutative-mul-Large-Commutative-Monoid M x y)
+
+  large-commutative-monoid-Large-Commutative-Submonoid :
+    Large-Commutative-Monoid (λ l → α l ⊔ γ l) β
+  large-commutative-monoid-Large-Commutative-Submonoid =
+    make-Large-Commutative-Monoid
+      ( large-monoid-Large-Commutative-Submonoid)
+      ( commutative-mul-Large-Commutative-Submonoid)
+```
+
+### The inclusion homomorphism of a large commutative submonoid
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Commutative-Monoid α β}
+  (S : Large-Commutative-Submonoid γ M)
+  where
+
+  inclusion-hom-Large-Commutative-Submonoid :
+    hom-Large-Commutative-Monoid
+      ( large-commutative-monoid-Large-Commutative-Submonoid S)
+      ( M)
+  inclusion-hom-Large-Commutative-Submonoid =
+    make-hom-Large-Commutative-Monoid
+      ( inclusion-hom-Large-Submonoid
+        ( large-submonoid-Large-Commutative-Submonoid S))
+```
+
+### Small commutative submonoids from large commutative submonoids
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Commutative-Monoid α β}
+  (S : Large-Commutative-Submonoid γ M)
+  where
+
+  commutative-submonoid-Large-Commutative-Submonoid :
+    (l : Level) →
+    Commutative-Submonoid
+      ( γ l)
+      ( commutative-monoid-Large-Commutative-Monoid M l)
+  commutative-submonoid-Large-Commutative-Submonoid =
+    submonoid-Large-Submonoid (large-submonoid-Large-Commutative-Submonoid S)
+```

--- a/src/group-theory/large-groups.lagda.md
+++ b/src/group-theory/large-groups.lagda.md
@@ -28,6 +28,7 @@ open import foundation.universe-levels
 open import group-theory.groups
 open import group-theory.homomorphisms-groups
 open import group-theory.large-monoids
+open import group-theory.large-semigroups
 open import group-theory.monoids
 open import group-theory.semigroups
 ```
@@ -49,6 +50,10 @@ record Large-Group (α : Level → Level) (β : Level → Level → Level) : UU�
 
   field
     large-monoid-Large-Group : Large-Monoid α β
+
+  large-semigroup-Large-Group : Large-Semigroup α β
+  large-semigroup-Large-Group =
+    large-semigroup-Large-Monoid large-monoid-Large-Group
 
   cumulative-large-set-Large-Group : Cumulative-Large-Set α β
   cumulative-large-set-Large-Group =

--- a/src/group-theory/large-subgroups.lagda.md
+++ b/src/group-theory/large-subgroups.lagda.md
@@ -1,0 +1,226 @@
+# Large subgroups
+
+```agda
+module group-theory.large-subgroups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cumulative-large-sets
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.subsets-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-groups
+open import group-theory.large-groups
+open import group-theory.large-monoids
+open import group-theory.large-submonoids
+open import group-theory.large-subsemigroups
+open import group-theory.subgroups
+open import group-theory.subsets-large-groups
+```
+
+</details>
+
+## Idea
+
+A {{#concept "subgroup" Disambiguation="of a large group" Agda=Large-Subgroup}}
+of a [large group](group-theory.large-subgroups.md) `G` is a
+[subset](group-theory.subsets-large-groups.md) `G` that contains the unit and is
+closed under multiplication and inverses.
+
+## Definition
+
+```agda
+record
+  Large-Subgroup
+    {α : Level → Level}
+    {β : Level → Level → Level}
+    (γ : Level → Level)
+    (G : Large-Group α β) :
+    UUω
+  where
+
+  constructor
+    make-Large-Subgroup
+
+  field
+    large-submonoid-Large-Subgroup :
+      Large-Submonoid γ (large-monoid-Large-Group G)
+
+  large-subsemigroup-Large-Subgroup :
+    Large-Subsemigroup γ (large-semigroup-Large-Group G)
+  large-subsemigroup-Large-Subgroup =
+    large-subsemigroup-Large-Submonoid large-submonoid-Large-Subgroup
+
+  subset-Large-Subgroup : subset-Large-Group γ G
+  subset-Large-Subgroup =
+    subset-Large-Submonoid large-submonoid-Large-Subgroup
+
+  type-Large-Subgroup : (l : Level) → UU (α l ⊔ γ l)
+  type-Large-Subgroup =
+    type-Large-Submonoid large-submonoid-Large-Subgroup
+
+  inclusion-Large-Subgroup :
+    {l : Level} → type-Large-Subgroup l → type-Large-Group G l
+  inclusion-Large-Subgroup = pr1
+
+  is-in-Large-Subgroup :
+    {l : Level} → type-Large-Group G l → UU (γ l)
+  is-in-Large-Subgroup =
+    is-in-Large-Submonoid large-submonoid-Large-Subgroup
+
+  prop-is-in-Large-Subgroup :
+    {l : Level} → type-Large-Group G l → Prop (γ l)
+  prop-is-in-Large-Subgroup =
+    prop-is-in-Large-Submonoid large-submonoid-Large-Subgroup
+
+  field
+    is-closed-under-inv-Large-Subgroup :
+      is-closed-under-inv-subset-Large-Group G subset-Large-Subgroup
+
+  abstract
+    eq-type-Large-Subgroup :
+      {l : Level} {x y : type-Large-Subgroup l} →
+      inclusion-Large-Subgroup x ＝ inclusion-Large-Subgroup y →
+      x ＝ y
+    eq-type-Large-Subgroup =
+      eq-type-Large-Submonoid large-submonoid-Large-Subgroup
+
+  cumulative-large-set-Large-Subgroup :
+    Cumulative-Large-Set (λ l → α l ⊔ γ l) β
+  cumulative-large-set-Large-Subgroup =
+    cumulative-large-set-Subset-Cumulative-Large-Set subset-Large-Subgroup
+
+  contains-unit-Large-Subgroup :
+    is-in-Large-Subgroup (unit-Large-Group G)
+  contains-unit-Large-Subgroup =
+    contains-unit-Large-Submonoid large-submonoid-Large-Subgroup
+
+  contains-raise-unit-Large-Subgroup :
+    (l : Level) → is-in-Large-Subgroup (raise-unit-Large-Group G l)
+  contains-raise-unit-Large-Subgroup =
+    contains-raise-unit-Large-Submonoid large-submonoid-Large-Subgroup
+
+  is-closed-under-mul-subset-Large-Subgroup :
+    is-closed-under-mul-subset-Large-Group
+      ( G)
+      ( subset-Large-Subgroup)
+  is-closed-under-mul-subset-Large-Subgroup =
+    is-closed-under-mul-subset-Large-Submonoid large-submonoid-Large-Subgroup
+
+open Large-Subgroup public
+```
+
+## Properties
+
+### Large subgroups induce large groups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Group α β}
+  (S : Large-Subgroup γ G)
+  where
+
+  large-monoid-Large-Subgroup :
+    Large-Monoid (λ l → α l ⊔ γ l) β
+  large-monoid-Large-Subgroup =
+    large-monoid-Large-Submonoid (large-submonoid-Large-Subgroup S)
+
+  mul-Large-Subgroup :
+    {l1 l2 : Level} →
+    type-Large-Subgroup S l1 → type-Large-Subgroup S l2 →
+    type-Large-Subgroup S (l1 ⊔ l2)
+  mul-Large-Subgroup = mul-Large-Monoid large-monoid-Large-Subgroup
+
+  inv-Large-Subgroup :
+    {l : Level} → type-Large-Subgroup S l → type-Large-Subgroup S l
+  inv-Large-Subgroup (x , x∈S) =
+    ( inv-Large-Group G x , is-closed-under-inv-Large-Subgroup S x x∈S)
+
+  unit-Large-Subgroup : type-Large-Subgroup S lzero
+  unit-Large-Subgroup = unit-Large-Monoid large-monoid-Large-Subgroup
+
+  raise-unit-Large-Subgroup : (l : Level) → type-Large-Subgroup S l
+  raise-unit-Large-Subgroup =
+    raise-unit-Large-Monoid large-monoid-Large-Subgroup
+
+  abstract
+    preserves-sim-inv-Large-Subgroup :
+      preserves-sim-endomap-Cumulative-Large-Set
+        ( id)
+        ( cumulative-large-set-Large-Subgroup S)
+        ( inv-Large-Subgroup)
+    preserves-sim-inv-Large-Subgroup (x , _) (y , _) =
+      preserves-sim-inv-Large-Group G x y
+
+    left-inverse-law-mul-Large-Subgroup :
+      {l : Level} (x : type-Large-Subgroup S l) →
+      mul-Large-Subgroup (inv-Large-Subgroup x) x ＝ raise-unit-Large-Subgroup l
+    left-inverse-law-mul-Large-Subgroup (x , _) =
+      eq-type-Large-Subgroup
+        ( S)
+        ( left-inverse-law-mul-Large-Group G x)
+
+    right-inverse-law-mul-Large-Subgroup :
+      {l : Level} (x : type-Large-Subgroup S l) →
+      mul-Large-Subgroup x (inv-Large-Subgroup x) ＝ raise-unit-Large-Subgroup l
+    right-inverse-law-mul-Large-Subgroup (x , _) =
+      eq-type-Large-Subgroup
+        ( S)
+        ( right-inverse-law-mul-Large-Group G x)
+
+  large-group-Large-Subgroup : Large-Group (λ l → α l ⊔ γ l) β
+  large-group-Large-Subgroup =
+    make-Large-Group
+      ( large-monoid-Large-Subgroup)
+      ( inv-Large-Subgroup)
+      ( preserves-sim-inv-Large-Subgroup)
+      ( left-inverse-law-mul-Large-Subgroup)
+      ( right-inverse-law-mul-Large-Subgroup)
+```
+
+### The inclusion homomorphism of large subgroups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Group α β}
+  (S : Large-Subgroup γ G)
+  where
+
+  inclusion-hom-Large-Subgroup :
+    hom-Large-Group
+      ( large-group-Large-Subgroup S)
+      ( G)
+  inclusion-hom-Large-Subgroup =
+    make-hom-Large-Group
+      ( inclusion-hom-Large-Subsemigroup
+        ( large-subsemigroup-Large-Subgroup S))
+```
+
+### Small subgroups from large subgroups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Group α β}
+  (S : Large-Subgroup γ G)
+  where
+
+  subgroup-Large-Subgroup : (l : Level) → Subgroup (γ l) (group-Large-Group G l)
+  subgroup-Large-Subgroup l =
+    ( prop-is-in-Large-Subgroup S ,
+      contains-raise-unit-Large-Subgroup S l ,
+      is-closed-under-mul-subset-Large-Subgroup S _ _ ,
+      is-closed-under-inv-Large-Subgroup S _)
+```

--- a/src/group-theory/large-submonoids.lagda.md
+++ b/src/group-theory/large-submonoids.lagda.md
@@ -1,0 +1,196 @@
+# Large submonoids
+
+```agda
+module group-theory.large-submonoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.dependent-pair-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-monoids
+open import group-theory.large-monoids
+open import group-theory.large-subsemigroups
+open import group-theory.monoids
+open import group-theory.submonoids
+open import group-theory.subsets-large-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "submonoid" Disambiguation="of a large monoid" Agda=Large-Submonoid}}
+of a [large monoid](group-theory.large-monoids.md) `M` is a
+[subset](group-theory.subsets-large-monoids.md) of `M` that is closed under
+multiplication and contains the unit.
+
+## Definition
+
+```agda
+record
+  Large-Submonoid
+    {α : Level → Level}
+    {β : Level → Level → Level}
+    (γ : Level → Level)
+    (M : Large-Monoid α β) :
+    UUω
+  where
+
+  constructor
+    make-Large-Submonoid
+
+  field
+    large-subsemigroup-Large-Submonoid :
+      Large-Subsemigroup γ (large-semigroup-Large-Monoid M)
+
+    contains-unit-Large-Submonoid :
+      is-in-Large-Subsemigroup
+        ( large-subsemigroup-Large-Submonoid)
+        ( unit-Large-Monoid M)
+
+  type-Large-Submonoid : (l : Level) → UU (α l ⊔ γ l)
+  type-Large-Submonoid =
+    type-Large-Subsemigroup large-subsemigroup-Large-Submonoid
+
+  is-in-Large-Submonoid :
+    {l : Level} → type-Large-Monoid M l → UU (γ l)
+  is-in-Large-Submonoid =
+    is-in-Large-Subsemigroup large-subsemigroup-Large-Submonoid
+
+  prop-is-in-Large-Submonoid :
+    {l : Level} → type-Large-Monoid M l → Prop (γ l)
+  prop-is-in-Large-Submonoid =
+    prop-is-in-Large-Subsemigroup large-subsemigroup-Large-Submonoid
+
+  inclusion-Large-Submonoid :
+    {l : Level} → type-Large-Submonoid l → type-Large-Monoid M l
+  inclusion-Large-Submonoid = pr1
+
+  subset-Large-Submonoid : subset-Large-Monoid γ M
+  subset-Large-Submonoid =
+    subset-Large-Subsemigroup large-subsemigroup-Large-Submonoid
+
+  is-closed-under-mul-subset-Large-Submonoid :
+    is-closed-under-mul-subset-Large-Monoid M subset-Large-Submonoid
+  is-closed-under-mul-subset-Large-Submonoid =
+    is-closed-under-mul-subset-Large-Subsemigroup
+      ( large-subsemigroup-Large-Submonoid)
+
+  is-closed-under-raise-subset-Large-Submonoid :
+    {l1 : Level} (l2 : Level) (x : type-Large-Monoid M l1) →
+    is-in-Large-Submonoid x →
+    is-in-Large-Submonoid (raise-Large-Monoid M l2 x)
+  is-closed-under-raise-subset-Large-Submonoid =
+    is-closed-under-raise-subset-Large-Monoid
+      ( M)
+      ( subset-Large-Submonoid)
+
+  abstract
+    eq-type-Large-Submonoid :
+      {l : Level} {x y : type-Large-Submonoid l} →
+      inclusion-Large-Submonoid x ＝ inclusion-Large-Submonoid y →
+      x ＝ y
+    eq-type-Large-Submonoid =
+      eq-type-Large-Subsemigroup large-subsemigroup-Large-Submonoid
+
+open Large-Submonoid public
+```
+
+## Properties
+
+### A large submonoid induces a large monoid
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Monoid α β}
+  (S : Large-Submonoid γ M)
+  where
+
+  mul-Large-Submonoid :
+    {l1 l2 : Level} →
+    type-Large-Submonoid S l1 → type-Large-Submonoid S l2 →
+    type-Large-Submonoid S (l1 ⊔ l2)
+  mul-Large-Submonoid =
+    mul-Large-Subsemigroup (large-subsemigroup-Large-Submonoid S)
+
+  unit-Large-Submonoid : type-Large-Submonoid S lzero
+  unit-Large-Submonoid =
+    ( unit-Large-Monoid M ,
+      contains-unit-Large-Submonoid S)
+
+  abstract
+    left-unit-law-mul-Large-Submonoid :
+      {l : Level} (x : type-Large-Submonoid S l) →
+      mul-Large-Submonoid unit-Large-Submonoid x ＝ x
+    left-unit-law-mul-Large-Submonoid (x , _) =
+      eq-type-Large-Submonoid S (left-unit-law-mul-Large-Monoid M x)
+
+    right-unit-law-mul-Large-Submonoid :
+      {l : Level} (x : type-Large-Submonoid S l) →
+      mul-Large-Submonoid x unit-Large-Submonoid ＝ x
+    right-unit-law-mul-Large-Submonoid (x , _) =
+      eq-type-Large-Submonoid S (right-unit-law-mul-Large-Monoid M x)
+
+  large-monoid-Large-Submonoid : Large-Monoid (λ l → α l ⊔ γ l) β
+  large-monoid-Large-Submonoid =
+    make-Large-Monoid
+      ( large-semigroup-Large-Subsemigroup
+        ( large-subsemigroup-Large-Submonoid S))
+      ( unit-Large-Submonoid)
+      ( left-unit-law-mul-Large-Submonoid)
+      ( right-unit-law-mul-Large-Submonoid)
+```
+
+### Small submonoids from large submonoids
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Monoid α β}
+  (S : Large-Submonoid γ M)
+  where
+
+  abstract
+    contains-raise-unit-Large-Submonoid :
+      (l : Level) → is-in-Large-Submonoid S (raise-unit-Large-Monoid M l)
+    contains-raise-unit-Large-Submonoid l =
+      is-closed-under-raise-subset-Large-Submonoid
+        ( S)
+        ( l)
+        ( unit-Large-Monoid M)
+        ( contains-unit-Large-Submonoid S)
+
+  submonoid-Large-Submonoid :
+    (l : Level) → Submonoid (γ l) (monoid-Large-Monoid M l)
+  submonoid-Large-Submonoid l =
+    ( prop-is-in-Large-Submonoid S ,
+      contains-raise-unit-Large-Submonoid l ,
+      is-closed-under-mul-subset-Large-Submonoid S)
+```
+
+### The inclusion homomorphism of a submonoid
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {M : Large-Monoid α β}
+  (S : Large-Submonoid γ M)
+  where
+
+  inclusion-hom-Large-Submonoid :
+    hom-Large-Monoid (large-monoid-Large-Submonoid S) M
+  inclusion-hom-Large-Submonoid =
+    make-hom-Large-Monoid
+      ( inclusion-hom-Large-Subsemigroup (large-subsemigroup-Large-Submonoid S))
+      ( refl)
+```

--- a/src/group-theory/large-subsemigroups.lagda.md
+++ b/src/group-theory/large-subsemigroups.lagda.md
@@ -1,0 +1,194 @@
+# Large subsemigroups
+
+```agda
+module group-theory.large-subsemigroups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cumulative-large-sets
+open import foundation.dependent-pair-types
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.similarity-preserving-binary-maps-cumulative-large-sets
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.homomorphisms-large-semigroups
+open import group-theory.large-semigroups
+open import group-theory.semigroups
+open import group-theory.subsemigroups
+open import group-theory.subsets-large-semigroups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subsemigroup" Disambiguation="of a large semigroup" Agda=Large-Subsemigroup}}
+of a [large semigroup](group-theory.large-semigroups.md) `G` is a
+[subset](group-theory.subsets-large-semigroups.md) of `G` that is closed under
+multiplication.
+
+## Definition
+
+```agda
+record
+  Large-Subsemigroup
+    {α : Level → Level}
+    {β : Level → Level → Level}
+    (γ : Level → Level)
+    (G : Large-Semigroup α β) :
+    UUω
+  where
+
+  field
+    subset-Large-Subsemigroup : subset-Large-Semigroup γ G
+
+    is-closed-under-mul-subset-Large-Subsemigroup :
+      is-closed-under-mul-subset-Large-Semigroup
+        ( G)
+        ( subset-Large-Subsemigroup)
+
+  type-Large-Subsemigroup : (l : Level) → UU (α l ⊔ γ l)
+  type-Large-Subsemigroup =
+    type-subset-Large-Semigroup G subset-Large-Subsemigroup
+
+  cumulative-large-set-Large-Subsemigroup :
+    Cumulative-Large-Set (λ l → α l ⊔ γ l) β
+  cumulative-large-set-Large-Subsemigroup =
+    cumulative-large-set-subset-Large-Semigroup G subset-Large-Subsemigroup
+
+  inclusion-Large-Subsemigroup :
+    {l : Level} → type-Large-Subsemigroup l → type-Large-Semigroup G l
+  inclusion-Large-Subsemigroup = pr1
+
+  is-in-Large-Subsemigroup :
+    {l : Level} → type-Large-Semigroup G l → UU (γ l)
+  is-in-Large-Subsemigroup =
+    is-in-subset-Large-Semigroup G subset-Large-Subsemigroup
+
+  prop-is-in-Large-Subsemigroup :
+    {l : Level} → type-Large-Semigroup G l → Prop (γ l)
+  prop-is-in-Large-Subsemigroup =
+    prop-is-in-subset-Large-Semigroup G subset-Large-Subsemigroup
+
+  abstract
+    eq-type-Large-Subsemigroup :
+      {l : Level} {x y : type-Large-Subsemigroup l} →
+      inclusion-Large-Subsemigroup x ＝ inclusion-Large-Subsemigroup y →
+      x ＝ y
+    eq-type-Large-Subsemigroup =
+      eq-type-subset-Large-Semigroup G subset-Large-Subsemigroup
+
+open Large-Subsemigroup public
+```
+
+## Properties
+
+### A large subsemigroup induces a large semigroup
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Semigroup α β}
+  (S : Large-Subsemigroup γ G)
+  where
+
+  mul-Large-Subsemigroup :
+    {l1 l2 : Level} →
+    type-Large-Subsemigroup S l1 → type-Large-Subsemigroup S l2 →
+    type-Large-Subsemigroup S (l1 ⊔ l2)
+  mul-Large-Subsemigroup (x , x∈S) (y , y∈S) =
+    ( mul-Large-Semigroup G x y ,
+      is-closed-under-mul-subset-Large-Subsemigroup S x y x∈S y∈S)
+
+  abstract
+    preserves-sim-mul-Large-Subsemigroup :
+      preserves-sim-binary-operator-Cumulative-Large-Set
+        ( cumulative-large-set-Large-Subsemigroup S)
+        ( mul-Large-Subsemigroup)
+    preserves-sim-mul-Large-Subsemigroup (x , _) (x' , _) (y , _) (y' , _) =
+      preserves-sim-mul-Large-Semigroup G x x' y y'
+
+  sim-preserving-binary-operator-mul-Large-Subsemigroup :
+    sim-preserving-binary-operator-Cumulative-Large-Set
+      ( cumulative-large-set-Large-Subsemigroup S)
+  sim-preserving-binary-operator-mul-Large-Subsemigroup =
+    make-sim-preserving-binary-operator-Cumulative-Large-Set
+      ( cumulative-large-set-Large-Subsemigroup S)
+      ( mul-Large-Subsemigroup)
+      ( preserves-sim-mul-Large-Subsemigroup)
+
+  abstract
+    associative-mul-Large-Subsemigroup :
+      {l1 l2 l3 : Level}
+      (x : type-Large-Subsemigroup S l1)
+      (y : type-Large-Subsemigroup S l2)
+      (z : type-Large-Subsemigroup S l3) →
+      mul-Large-Subsemigroup (mul-Large-Subsemigroup x y) z ＝
+      mul-Large-Subsemigroup x (mul-Large-Subsemigroup y z)
+    associative-mul-Large-Subsemigroup (x , _) (y , _) (z , _) =
+      eq-type-Large-Subsemigroup
+        ( S)
+        ( associative-mul-Large-Semigroup G x y z)
+
+  large-semigroup-Large-Subsemigroup :
+    Large-Semigroup (λ l → α l ⊔ γ l) β
+  large-semigroup-Large-Subsemigroup =
+    make-Large-Semigroup
+      ( cumulative-large-set-Large-Subsemigroup S)
+      ( sim-preserving-binary-operator-mul-Large-Subsemigroup)
+      ( associative-mul-Large-Subsemigroup)
+```
+
+### The inclusion homomorphism of a large subsemigroup
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Semigroup α β}
+  (S : Large-Subsemigroup γ G)
+  where
+
+  sim-preserving-map-inclusion-Large-Subsemigroup :
+    sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-Large-Subsemigroup S)
+      ( cumulative-large-set-Large-Semigroup G)
+  sim-preserving-map-inclusion-Large-Subsemigroup =
+    sim-preserving-map-inclusion-subset-Large-Semigroup
+      ( G)
+      ( subset-Large-Subsemigroup S)
+
+  inclusion-hom-Large-Subsemigroup :
+    hom-Large-Semigroup
+      ( large-semigroup-Large-Subsemigroup S)
+      ( G)
+  inclusion-hom-Large-Subsemigroup =
+    make-hom-Large-Semigroup
+      ( sim-preserving-map-inclusion-Large-Subsemigroup)
+      ( refl)
+```
+
+### Small subsemigroups from large subsemigroups
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  {G : Large-Semigroup α β}
+  (S : Large-Subsemigroup γ G)
+  where
+
+  subsemigroup-Large-Subsemigroup :
+    (l : Level) → Subsemigroup (γ l) (semigroup-Large-Semigroup G l)
+  subsemigroup-Large-Subsemigroup l =
+    ( prop-is-in-Large-Subsemigroup S ,
+      is-closed-under-mul-subset-Large-Subsemigroup S _ _)
+```

--- a/src/group-theory/subsemigroups.lagda.md
+++ b/src/group-theory/subsemigroups.lagda.md
@@ -36,8 +36,9 @@ open import order-theory.preorders
 
 ## Idea
 
-A subsemigroup of a semigroup `G` is a subtype of `G` closed under
-multiplication.
+A {{#concept "subsemigroup" Agda=Subsemigroup}} of a
+[semigroup](group-theory.semigroups.md) `G` is a
+[subset](group-theory.subsets-semigroups.md) of `G` closed under multiplication.
 
 ## Definitions
 

--- a/src/group-theory/subsets-large-abelian-groups.lagda.md
+++ b/src/group-theory/subsets-large-abelian-groups.lagda.md
@@ -1,0 +1,93 @@
+# Subsets of large abelian groups
+
+```agda
+module group-theory.subsets-large-abelian-groups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.propositions
+open import foundation.universe-levels
+
+open import group-theory.large-abelian-groups
+open import group-theory.subsets-large-groups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a large abelian group" Agda=subset-Large-Ab}}
+of a [large abelian group](group-theory.large-abelian-groups.md) is a
+[subset](foundation.subsets-cumulative-large-sets.md) of the
+[cumulative large set](foundation.cumulative-large-sets.md) of the large abelian
+group.
+
+## Definition
+
+```agda
+subset-Large-Ab :
+  {α : Level → Level} {β : Level → Level → Level} →
+  (Level → Level) → Large-Ab α β → UUω
+subset-Large-Ab γ G =
+  subset-Large-Group γ (large-group-Large-Ab G)
+```
+
+## Properties
+
+### The property of being closed under addition
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (G : Large-Ab α β)
+  (S : subset-Large-Ab γ G)
+  where
+
+  is-closed-under-add-subset-Large-Ab : UUω
+  is-closed-under-add-subset-Large-Ab =
+    is-closed-under-mul-subset-Large-Group
+      ( large-group-Large-Ab G)
+      ( S)
+```
+
+### The property of being closed under negation
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (G : Large-Ab α β)
+  (S : subset-Large-Ab γ G)
+  where
+
+  is-closed-under-neg-subset-Large-Ab : UUω
+  is-closed-under-neg-subset-Large-Ab =
+    is-closed-under-inv-subset-Large-Group
+      ( large-group-Large-Ab G)
+      ( S)
+```
+
+### The property of containing zero
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (G : Large-Ab α β)
+  (S : subset-Large-Ab γ G)
+  where
+
+  contains-zero-prop-subset-Large-Ab : Prop (γ lzero)
+  contains-zero-prop-subset-Large-Ab =
+    contains-unit-prop-subset-Large-Group
+      ( large-group-Large-Ab G)
+      ( S)
+
+  contains-zero-subset-Large-Ab : UU (γ lzero)
+  contains-zero-subset-Large-Ab =
+    type-Prop contains-zero-prop-subset-Large-Ab
+```

--- a/src/group-theory/subsets-large-commutative-monoids.lagda.md
+++ b/src/group-theory/subsets-large-commutative-monoids.lagda.md
@@ -1,0 +1,76 @@
+# Subsets of large commutative monoids
+
+```agda
+module group-theory.subsets-large-commutative-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.propositions
+open import foundation.universe-levels
+
+open import group-theory.large-commutative-monoids
+open import group-theory.subsets-large-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a large commutative monoid" Agda=subset-Large-Commutative-Monoid}}
+of a [large commutative monoid](group-theory.large-commutative-monoid.md) is a
+[subset](foundation.subsets-cumulative-large-sets.md) of the
+[cumulative large set](foundation.cumulative-large-sets.md) of the large
+commutative monoid.
+
+## Definition
+
+```agda
+subset-Large-Commutative-Monoid :
+  {α : Level → Level} {β : Level → Level → Level} →
+  (Level → Level) → Large-Commutative-Monoid α β → UUω
+subset-Large-Commutative-Monoid γ M =
+  subset-Large-Monoid γ (large-monoid-Large-Commutative-Monoid M)
+```
+
+## Properties
+
+### The property of being closed under multiplication
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (M : Large-Commutative-Monoid α β)
+  (S : subset-Large-Commutative-Monoid γ M)
+  where
+
+  is-closed-under-mul-subset-Large-Commutative-Monoid : UUω
+  is-closed-under-mul-subset-Large-Commutative-Monoid =
+    is-closed-under-mul-subset-Large-Monoid
+      ( large-monoid-Large-Commutative-Monoid M)
+      ( S)
+```
+
+### The property of containing the unit
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (M : Large-Commutative-Monoid α β)
+  (S : subset-Large-Commutative-Monoid γ M)
+  where
+
+  contains-unit-prop-subset-Large-Commutative-Monoid : Prop (γ lzero)
+  contains-unit-prop-subset-Large-Commutative-Monoid =
+    contains-unit-prop-subset-Large-Monoid
+      ( large-monoid-Large-Commutative-Monoid M)
+      ( S)
+
+  contains-unit-subset-Large-Commutative-Monoid : UU (γ lzero)
+  contains-unit-subset-Large-Commutative-Monoid =
+    type-Prop contains-unit-prop-subset-Large-Commutative-Monoid
+```

--- a/src/group-theory/subsets-large-commutative-monoids.lagda.md
+++ b/src/group-theory/subsets-large-commutative-monoids.lagda.md
@@ -20,7 +20,7 @@ open import group-theory.subsets-large-monoids
 
 A
 {{#concept "subset" Disambiguation="of a large commutative monoid" Agda=subset-Large-Commutative-Monoid}}
-of a [large commutative monoid](group-theory.large-commutative-monoid.md) is a
+of a [large commutative monoid](group-theory.large-commutative-monoids.md) is a
 [subset](foundation.subsets-cumulative-large-sets.md) of the
 [cumulative large set](foundation.cumulative-large-sets.md) of the large
 commutative monoid.

--- a/src/group-theory/subsets-large-groups.lagda.md
+++ b/src/group-theory/subsets-large-groups.lagda.md
@@ -1,0 +1,99 @@
+# Subsets of large groups
+
+```agda
+module group-theory.subsets-large-groups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.propositions
+open import foundation.universe-levels
+
+open import group-theory.large-groups
+open import group-theory.subsets-large-monoids
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a large group" Agda=subset-Large-Group}}
+of a [large group](group-theory.large-groups.md) is a
+[subset](foundation.subsets-cumulative-large-sets.md) of the
+[cumulative large set](foundation.cumulative-large-sets.md) of the large group.
+
+## Definition
+
+```agda
+subset-Large-Group :
+  {α : Level → Level} {β : Level → Level → Level} →
+  (Level → Level) → Large-Group α β → UUω
+subset-Large-Group γ G = subset-Large-Monoid γ (large-monoid-Large-Group G)
+
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Group α β)
+  (S : subset-Large-Group γ G)
+  where
+
+  is-in-subset-Large-Group :
+    {l : Level} → type-Large-Group G l → UU (γ l)
+  is-in-subset-Large-Group =
+    is-in-subset-Large-Monoid (large-monoid-Large-Group G) S
+```
+
+## Properties
+
+### The property of being closed under multiplication
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Group α β)
+  (S : subset-Large-Group γ G)
+  where
+
+  is-closed-under-mul-subset-Large-Group : UUω
+  is-closed-under-mul-subset-Large-Group =
+    is-closed-under-mul-subset-Large-Monoid
+      ( large-monoid-Large-Group G)
+      ( S)
+```
+
+### The property of containing the unit
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Group α β)
+  (S : subset-Large-Group γ G)
+  where
+
+  contains-unit-prop-subset-Large-Group : Prop (γ lzero)
+  contains-unit-prop-subset-Large-Group =
+    contains-unit-prop-subset-Large-Monoid
+      ( large-monoid-Large-Group G)
+      ( S)
+
+  contains-unit-subset-Large-Group : UU (γ lzero)
+  contains-unit-subset-Large-Group =
+    type-Prop contains-unit-prop-subset-Large-Group
+```
+
+### The property of being closed under inverses
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Group α β)
+  (S : subset-Large-Group γ G)
+  where
+
+  is-closed-under-inv-subset-Large-Group : UUω
+  is-closed-under-inv-subset-Large-Group =
+    {l : Level} (x : type-Large-Group G l) →
+    is-in-subset-Large-Group G S x →
+    is-in-subset-Large-Group G S (inv-Large-Group G x)
+```

--- a/src/group-theory/subsets-large-monoids.lagda.md
+++ b/src/group-theory/subsets-large-monoids.lagda.md
@@ -1,0 +1,105 @@
+# Subsets of large monoids
+
+```agda
+module group-theory.subsets-large-monoids where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.propositions
+open import foundation.subsets-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.large-monoids
+open import group-theory.subsets-large-semigroups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a large monoid" Agda=subset-Large-Monoid}}
+of a [large monoid](group-theory.large-monoids.md) is a
+[subset](foundation.subsets-cumulative-large-sets.md) of the
+[cumulative large set](foundation.cumulative-large-sets.md) of the large monoid.
+
+## Definition
+
+```agda
+subset-Large-Monoid :
+  {α : Level → Level} {β : Level → Level → Level} →
+  (Level → Level) → Large-Monoid α β → UUω
+subset-Large-Monoid γ M =
+  subset-Large-Semigroup γ (large-semigroup-Large-Monoid M)
+
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (M : Large-Monoid α β)
+  (S : subset-Large-Monoid γ M)
+  where
+
+  type-subset-Large-Monoid :
+    (l : Level) → UU (α l ⊔ γ l)
+  type-subset-Large-Monoid =
+    type-subset-Large-Semigroup (large-semigroup-Large-Monoid M) S
+
+  is-in-subset-Large-Monoid :
+    {l : Level} → type-Large-Monoid M l → UU (γ l)
+  is-in-subset-Large-Monoid =
+    is-in-subset-Large-Semigroup (large-semigroup-Large-Monoid M) S
+
+  prop-is-in-subset-Large-Monoid :
+    {l : Level} → type-Large-Monoid M l → Prop (γ l)
+  prop-is-in-subset-Large-Monoid =
+    prop-is-in-subset-Large-Semigroup (large-semigroup-Large-Monoid M) S
+
+  abstract
+    is-closed-under-raise-subset-Large-Monoid :
+      {l1 : Level} (l2 : Level) (x : type-Large-Monoid M l1) →
+      is-in-subset-Large-Monoid x →
+      is-in-subset-Large-Monoid (raise-Large-Monoid M l2 x)
+    is-closed-under-raise-subset-Large-Monoid =
+      is-closed-under-raise-subset-Large-Semigroup
+        ( large-semigroup-Large-Monoid M)
+        ( S)
+```
+
+## Properties
+
+### The property of being closed under multiplication
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (M : Large-Monoid α β)
+  (S : subset-Large-Monoid γ M)
+  where
+
+  is-closed-under-mul-subset-Large-Monoid : UUω
+  is-closed-under-mul-subset-Large-Monoid =
+    is-closed-under-mul-subset-Large-Semigroup
+      ( large-semigroup-Large-Monoid M)
+      ( S)
+```
+
+### The property of containing the unit
+
+```agda
+module _
+  {α γ : Level → Level}
+  {β : Level → Level → Level}
+  (M : Large-Monoid α β)
+  (S : subset-Large-Monoid γ M)
+  where
+
+  contains-unit-prop-subset-Large-Monoid : Prop (γ lzero)
+  contains-unit-prop-subset-Large-Monoid =
+    prop-is-in-subset-Large-Monoid M S (unit-Large-Monoid M)
+
+  contains-unit-subset-Large-Monoid : UU (γ lzero)
+  contains-unit-subset-Large-Monoid =
+    type-Prop contains-unit-prop-subset-Large-Monoid
+```

--- a/src/group-theory/subsets-large-semigroups.lagda.md
+++ b/src/group-theory/subsets-large-semigroups.lagda.md
@@ -1,0 +1,109 @@
+# Subsets of large semigroups
+
+```agda
+module group-theory.subsets-large-semigroups where
+```
+
+<details><summary>Imports</summary>
+
+```agda
+open import foundation.cumulative-large-sets
+open import foundation.function-types
+open import foundation.identity-types
+open import foundation.propositions
+open import foundation.similarity-preserving-maps-cumulative-large-sets
+open import foundation.subsets-cumulative-large-sets
+open import foundation.universe-levels
+
+open import group-theory.large-semigroups
+```
+
+</details>
+
+## Idea
+
+A
+{{#concept "subset" Disambiguation="of a large semigroup" Agda=subset-Large-Semigroup}}
+of a [large semigroup](group-theory.large-semigroups.md) is a
+[subset](foundation.subsets-cumulative-large-sets.md) of the
+[cumulative large set](foundation.cumulative-large-sets.md) of the large
+semigroup.
+
+## Definition
+
+```agda
+subset-Large-Semigroup :
+  {α : Level → Level} {β : Level → Level → Level} →
+  (Level → Level) → Large-Semigroup α β → UUω
+subset-Large-Semigroup γ G =
+  Subset-Cumulative-Large-Set γ (cumulative-large-set-Large-Semigroup G)
+
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Semigroup α β)
+  (S : subset-Large-Semigroup γ G)
+  where
+
+  type-subset-Large-Semigroup : (l : Level) → UU (α l ⊔ γ l)
+  type-subset-Large-Semigroup = type-Subset-Cumulative-Large-Set S
+
+  inclusion-subset-Large-Semigroup :
+    {l : Level} → type-subset-Large-Semigroup l → type-Large-Semigroup G l
+  inclusion-subset-Large-Semigroup = inclusion-Subset-Cumulative-Large-Set S
+
+  is-in-subset-Large-Semigroup :
+    {l : Level} → type-Large-Semigroup G l → UU (γ l)
+  is-in-subset-Large-Semigroup =
+    is-in-Subset-Cumulative-Large-Set S
+
+  prop-is-in-subset-Large-Semigroup :
+    {l : Level} → type-Large-Semigroup G l → Prop (γ l)
+  prop-is-in-subset-Large-Semigroup =
+    prop-is-in-Subset-Cumulative-Large-Set S
+
+  cumulative-large-set-subset-Large-Semigroup :
+    Cumulative-Large-Set (λ l → α l ⊔ γ l) β
+  cumulative-large-set-subset-Large-Semigroup =
+    cumulative-large-set-Subset-Cumulative-Large-Set S
+
+  abstract
+    eq-type-subset-Large-Semigroup :
+      {l : Level} {x y : type-subset-Large-Semigroup l} →
+      inclusion-subset-Large-Semigroup x ＝ inclusion-subset-Large-Semigroup y →
+      x ＝ y
+    eq-type-subset-Large-Semigroup = eq-type-Subset-Cumulative-Large-Set S
+
+    is-closed-under-raise-subset-Large-Semigroup :
+      {l1 : Level} (l2 : Level) (x : type-Large-Semigroup G l1) →
+      is-in-subset-Large-Semigroup x →
+      is-in-subset-Large-Semigroup (raise-Large-Semigroup G l2 x)
+    is-closed-under-raise-subset-Large-Semigroup =
+      is-closed-under-raise-Subset-Cumulative-Large-Set S
+
+  sim-preserving-map-inclusion-subset-Large-Semigroup :
+    sim-preserving-map-Cumulative-Large-Set
+      ( id)
+      ( cumulative-large-set-subset-Large-Semigroup)
+      ( cumulative-large-set-Large-Semigroup G)
+  sim-preserving-map-inclusion-subset-Large-Semigroup =
+    sim-preserving-map-inclusion-Subset-Cumulative-Large-Set S
+```
+
+## Properties
+
+### The property of being closed under multiplication
+
+```agda
+module _
+  {α γ : Level → Level} {β : Level → Level → Level}
+  (G : Large-Semigroup α β)
+  (S : subset-Large-Semigroup γ G)
+  where
+
+  is-closed-under-mul-subset-Large-Semigroup : UUω
+  is-closed-under-mul-subset-Large-Semigroup =
+    {l1 l2 : Level}
+    (x : type-Large-Semigroup G l1) (y : type-Large-Semigroup G l2) →
+    is-in-subset-Large-Semigroup G S x → is-in-subset-Large-Semigroup G S y →
+    is-in-subset-Large-Semigroup G S (mul-Large-Semigroup G x y)
+```


### PR DESCRIPTION
Introduces everything between large subtypes and large abelian subgroups.

After this step, the goal is to reconcile the large algebraic structures of real numbers and their subsets (e.g. the positive real numbers under multiplication are a large submonoid of all real numbers under multiplication), allowing us to also reconcile the definitions of powers/exponentiation.